### PR TITLE
refactor: remove process.exit from command modules

### DIFF
--- a/bin/guild.js
+++ b/bin/guild.js
@@ -26,8 +26,13 @@ program
   .command('init')
   .description('Inicializar Guild v1 en el proyecto actual')
   .action(async () => {
-    const { runInit } = await import('../src/commands/init.js');
-    await runInit();
+    try {
+      const { runInit } = await import('../src/commands/init.js');
+      await runInit();
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
   });
 
 // guild new-agent
@@ -36,8 +41,13 @@ program
   .description('Crear un nuevo agente')
   .argument('<name>', 'Nombre del agente (lowercase, guiones)')
   .action(async (name) => {
-    const { runNewAgent } = await import('../src/commands/new-agent.js');
-    await runNewAgent(name);
+    try {
+      const { runNewAgent } = await import('../src/commands/new-agent.js');
+      await runNewAgent(name);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
   });
 
 // guild status
@@ -45,8 +55,13 @@ program
   .command('status')
   .description('Ver estado del proyecto Guild')
   .action(async () => {
-    const { runStatus } = await import('../src/commands/status.js');
-    await runStatus();
+    try {
+      const { runStatus } = await import('../src/commands/status.js');
+      await runStatus();
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
   });
 
 program.parse();

--- a/src/commands/__tests__/new-agent.test.js
+++ b/src/commands/__tests__/new-agent.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('runNewAgent', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-test-'));
+    originalCwd = process.cwd();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should throw with invalid agent name', async () => {
+    process.chdir(tempDir);
+    const { runNewAgent } = await import('../new-agent.js');
+    await expect(runNewAgent('Invalid Name!')).rejects.toThrow('Nombre invalido');
+  });
+
+  it('should throw when .claude/agents/ does not exist', async () => {
+    process.chdir(tempDir);
+    const { runNewAgent } = await import('../new-agent.js');
+    await expect(runNewAgent('valid-name')).rejects.toThrow('Guild no esta instalado');
+  });
+
+  it('should throw when agent already exists', async () => {
+    process.chdir(tempDir);
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'agents', 'existing.md'), '# existing');
+    const { runNewAgent } = await import('../new-agent.js');
+    await expect(runNewAgent('existing')).rejects.toThrow('ya existe');
+  });
+});

--- a/src/commands/__tests__/status.test.js
+++ b/src/commands/__tests__/status.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('runStatus', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-test-'));
+    originalCwd = process.cwd();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should throw when PROJECT.md does not exist', async () => {
+    process.chdir(tempDir);
+    const { runStatus } = await import('../status.js');
+    await expect(runStatus()).rejects.toThrow('Guild no esta instalado');
+  });
+
+  it('should not throw when PROJECT.md exists', async () => {
+    process.chdir(tempDir);
+    writeFileSync(join(tempDir, 'PROJECT.md'), '**Nombre:** TestProject\n**Stack:** Node.js');
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true });
+    const { runStatus } = await import('../status.js');
+    await expect(runStatus()).resolves.not.toThrow();
+  });
+});

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -28,7 +28,7 @@ export async function runInit() {
 
     if (p.isCancel(overwrite) || !overwrite) {
       p.cancel('Cancelado.');
-      process.exit(0);
+      return;
     }
   }
 
@@ -40,7 +40,7 @@ export async function runInit() {
       if (!val) return 'El nombre es requerido';
     },
   });
-  if (p.isCancel(name)) { p.cancel('Cancelado.'); process.exit(0); }
+  if (p.isCancel(name)) { p.cancel('Cancelado.'); return; }
 
   // ─── Tipo ───────────────────────────────────────────────────────────────────
   const type = await p.select({
@@ -53,7 +53,7 @@ export async function runInit() {
       { value: 'fullstack', label: 'Otro / Fullstack' },
     ],
   });
-  if (p.isCancel(type)) { p.cancel('Cancelado.'); process.exit(0); }
+  if (p.isCancel(type)) { p.cancel('Cancelado.'); return; }
 
   // ─── Stack ──────────────────────────────────────────────────────────────────
   const stack = await p.text({
@@ -63,7 +63,7 @@ export async function runInit() {
       if (!val) return 'El stack es requerido';
     },
   });
-  if (p.isCancel(stack)) { p.cancel('Cancelado.'); process.exit(0); }
+  if (p.isCancel(stack)) { p.cancel('Cancelado.'); return; }
 
   // ─── GitHub ─────────────────────────────────────────────────────────────────
   let github = null;
@@ -118,8 +118,7 @@ export async function runInit() {
     spinner.stop('Estructura creada.');
   } catch (error) {
     spinner.stop('Error durante la inicializacion.');
-    p.log.error(error.message);
-    process.exit(1);
+    throw error;
   }
 
   // ─── Resumen ────────────────────────────────────────────────────────────────

--- a/src/commands/new-agent.js
+++ b/src/commands/new-agent.js
@@ -21,22 +21,18 @@ export async function runNewAgent(agentName) {
 
   // Validar nombre
   if (!isValidAgentName(agentName)) {
-    p.log.error(`Nombre invalido: "${agentName}". Solo lowercase, numeros y guiones.`);
-    p.log.info('Ejemplo: guild new-agent security-auditor');
-    process.exit(1);
+    throw new Error(`Nombre invalido: "${agentName}". Solo lowercase, numeros y guiones. Ejemplo: guild new-agent security-auditor`);
   }
 
   // Verificar Guild instalado
   if (!existsSync(AGENTS_DIR)) {
-    p.log.error('Guild no esta instalado. Ejecuta: guild init');
-    process.exit(1);
+    throw new Error('Guild no esta instalado. Ejecuta: guild init');
   }
 
   // Verificar que el agente NO existe
   const agentPath = join(AGENTS_DIR, `${agentName}.md`);
   if (existsSync(agentPath)) {
-    p.log.error(`El agente "${agentName}" ya existe.`);
-    process.exit(1);
+    throw new Error(`El agente "${agentName}" ya existe.`);
   }
 
   // Pedir descripcion
@@ -45,7 +41,7 @@ export async function runNewAgent(agentName) {
     placeholder: 'ej: Evalua oportunidades de trading basado en analisis tecnico',
     validate: (val) => !val ? 'La descripcion es requerida' : undefined,
   });
-  if (p.isCancel(description)) { p.cancel('Cancelado.'); process.exit(0); }
+  if (p.isCancel(description)) { p.cancel('Cancelado.'); return; }
 
   // Crear agente
   const spinner = p.spinner();
@@ -87,8 +83,7 @@ Eres ${agentName} de [PROYECTO].
     p.outro(chalk.bold.cyan(`Agente ${agentName} listo.`));
   } catch (error) {
     spinner.stop('Error al crear agente.');
-    p.log.error(error.message);
-    process.exit(1);
+    throw error;
   }
 }
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -9,8 +9,7 @@ import { join } from 'path';
 
 export async function runStatus() {
   if (!existsSync('PROJECT.md')) {
-    p.log.error('Guild no esta instalado. Ejecuta: guild init');
-    process.exit(1);
+    throw new Error('Guild no esta instalado. Ejecuta: guild init');
   }
 
   const projectMd = readFileSync('PROJECT.md', 'utf8');


### PR DESCRIPTION
## Summary
- Replace `process.exit()` with `throw` in init.js, new-agent.js, status.js
- Add try/catch error boundary in bin/guild.js as single exit point
- Add tests for status and new-agent commands (5 new tests)

Closes #2

## Test plan
- [x] npm test passes (27 tests total)
- [x] npm run lint passes
- [ ] guild init still handles Ctrl+C gracefully
- [ ] guild status shows error message when not initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)