### PR TITLE
fix: remove unused fs-extra, add project root resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@clack/prompts": "^0.9.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
-        "fs-extra": "^11.2.0",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -1654,20 +1653,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1695,12 +1680,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -1772,18 +1751,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2201,15 +2168,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@clack/prompts": "^0.9.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
-    "fs-extra": "^11.2.0",
     "picocolors": "^1.0.0"
   },
   "engines": {

--- a/src/utils/__tests__/files.test.js
+++ b/src/utils/__tests__/files.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, existsSync, rmSync, readdirSync } from 'fs';
+import { mkdirSync, existsSync, rmSync, readdirSync, mkdtempSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { copyTemplates, getAgentNames } from '../files.js';
+import { tmpdir } from 'os';
+import { copyTemplates, getAgentNames, resolveProjectRoot } from '../files.js';
 
 const TEST_DIR = join(import.meta.dirname, '__tmp_files__');
 
@@ -82,5 +83,48 @@ describe('copyTemplates', () => {
       // Should not be a directory
       expect(existsSync(join(agentPath, 'base.md'))).toBe(false);
     }
+  });
+});
+
+// --- Tests for resolveProjectRoot ---
+
+describe('resolveProjectRoot', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-root-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return null when no project markers found', () => {
+    const result = resolveProjectRoot(tempDir);
+    expect(result).toBeNull();
+  });
+
+  it('should find root when .claude/ directory exists', () => {
+    mkdirSync(join(tempDir, '.claude'));
+    const result = resolveProjectRoot(tempDir);
+    expect(result).toBe(tempDir);
+  });
+
+  it('should find root when PROJECT.md exists', () => {
+    writeFileSync(join(tempDir, 'PROJECT.md'), '# Test');
+    const result = resolveProjectRoot(tempDir);
+    expect(result).toBe(tempDir);
+  });
+
+  it('should find root from nested subdirectory', () => {
+    mkdirSync(join(tempDir, '.claude'));
+    const nested = join(tempDir, 'sub1', 'sub2');
+    mkdirSync(nested, { recursive: true });
+    const result = resolveProjectRoot(nested);
+    expect(result).toBe(tempDir);
+  });
+
+  it('should not throw when called without arguments', () => {
+    expect(() => resolveProjectRoot()).not.toThrow();
   });
 });

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -3,7 +3,7 @@
  */
 
 import { mkdirSync, copyFileSync, existsSync, readdirSync, readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -79,4 +79,24 @@ export function readSessionMd() {
   const path = 'SESSION.md';
   if (!existsSync(path)) return null;
   return readFileSync(path, 'utf8');
+}
+
+/**
+ * Resuelve la raiz del proyecto Guild caminando hacia arriba desde startDir.
+ * Busca .claude/ o PROJECT.md como marcadores de un proyecto Guild.
+ * Retorna la ruta absoluta del proyecto o null si no se encuentra.
+ */
+export function resolveProjectRoot(startDir = process.cwd()) {
+  let dir = resolve(startDir);
+  while (true) {
+    if (existsSync(join(dir, '.claude')) || existsSync(join(dir, 'PROJECT.md'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      // Reached filesystem root without finding a project
+      return null;
+    }
+    dir = parent;
+  }
 }


### PR DESCRIPTION
## Summary
- Remove fs-extra from package.json (declared but never imported)
- Add `resolveProjectRoot()` utility to walk up and find project root
- Tests for resolveProjectRoot with various directory structures

Closes #3

## Test plan
- [x] npm test passes (27 tests)
- [x] npm run lint passes
- [x] No references to fs-extra in codebase
- [x] resolveProjectRoot finds root from nested dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)