### PR TITLE
feat: add guild doctor command (#4)

### DIFF
--- a/bin/guild.js
+++ b/bin/guild.js
@@ -64,4 +64,18 @@ program
     }
   });
 
+// guild doctor
+program
+  .command('doctor')
+  .description('Verify Guild setup and report issues')
+  .action(async () => {
+    try {
+      const { runDoctor } = await import('../src/commands/doctor.js');
+      await runDoctor();
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  });
+
 program.parse();

--- a/src/commands/__tests__/doctor.test.js
+++ b/src/commands/__tests__/doctor.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('runDoctor', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-doctor-'));
+    originalCwd = process.cwd();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should pass all checks for a healthy project', async () => {
+    // Setup a complete Guild project
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'skills', 'build-feature'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'agents', 'advisor.md'), '---\nname: advisor\n---');
+    writeFileSync(join(tempDir, '.claude', 'skills', 'build-feature', 'SKILL.md'), '---\nname: build-feature\n---');
+    writeFileSync(join(tempDir, 'CLAUDE.md'), '# CLAUDE');
+    writeFileSync(join(tempDir, 'PROJECT.md'), '# PROJECT');
+    writeFileSync(join(tempDir, 'SESSION.md'), '# SESSION');
+
+    process.chdir(tempDir);
+    const { runDoctor } = await import('../doctor.js');
+    // Should not throw for healthy project
+    await expect(runDoctor()).resolves.toBeUndefined();
+  });
+
+  it('should throw when .claude directory is missing', async () => {
+    writeFileSync(join(tempDir, 'CLAUDE.md'), '# CLAUDE');
+    writeFileSync(join(tempDir, 'PROJECT.md'), '# PROJECT');
+    writeFileSync(join(tempDir, 'SESSION.md'), '# SESSION');
+
+    process.chdir(tempDir);
+    const { runDoctor } = await import('../doctor.js');
+    await expect(runDoctor()).rejects.toThrow('Guild setup has issues');
+  });
+
+  it('should throw when agents directory is empty', async () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'skills', 'test-skill'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md'), '---\nname: test\n---');
+    writeFileSync(join(tempDir, 'CLAUDE.md'), '# CLAUDE');
+    writeFileSync(join(tempDir, 'PROJECT.md'), '# PROJECT');
+    writeFileSync(join(tempDir, 'SESSION.md'), '# SESSION');
+
+    process.chdir(tempDir);
+    const { runDoctor } = await import('../doctor.js');
+    await expect(runDoctor()).rejects.toThrow('Guild setup has issues');
+  });
+
+  it('should throw when CLAUDE.md is missing', async () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'skills', 'test-skill'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'agents', 'advisor.md'), '---\nname: advisor\n---');
+    writeFileSync(join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md'), '---\nname: test\n---');
+    writeFileSync(join(tempDir, 'PROJECT.md'), '# PROJECT');
+    writeFileSync(join(tempDir, 'SESSION.md'), '# SESSION');
+
+    process.chdir(tempDir);
+    const { runDoctor } = await import('../doctor.js');
+    await expect(runDoctor()).rejects.toThrow('Guild setup has issues');
+  });
+
+  it('should throw when PROJECT.md is missing', async () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'skills', 'test-skill'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'agents', 'advisor.md'), '---\nname: advisor\n---');
+    writeFileSync(join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md'), '---\nname: test\n---');
+    writeFileSync(join(tempDir, 'CLAUDE.md'), '# CLAUDE');
+    writeFileSync(join(tempDir, 'SESSION.md'), '# SESSION');
+
+    process.chdir(tempDir);
+    const { runDoctor } = await import('../doctor.js');
+    await expect(runDoctor()).rejects.toThrow('Guild setup has issues');
+  });
+});

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,0 +1,99 @@
+/**
+ * doctor.js — Validates Guild setup and reports actionable fixes
+ */
+
+import * as p from '@clack/prompts';
+import chalk from 'chalk';
+import { existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+export async function runDoctor() {
+  p.intro(chalk.bold.cyan('Guild — Doctor'));
+
+  const checks = [];
+  let healthy = true;
+
+  // Check .claude/ directory
+  if (existsSync('.claude')) {
+    checks.push({ name: '.claude/ directory', pass: true });
+  } else {
+    checks.push({ name: '.claude/ directory', pass: false, fix: 'Run: guild init' });
+    healthy = false;
+  }
+
+  // Check agents
+  const agentsDir = join('.claude', 'agents');
+  if (existsSync(agentsDir)) {
+    const agents = readdirSync(agentsDir).filter(f => f.endsWith('.md'));
+    if (agents.length > 0) {
+      checks.push({ name: `Agents (${agents.length} found)`, pass: true });
+    } else {
+      checks.push({ name: 'Agents', pass: false, fix: 'Run: guild init (no agent .md files found in .claude/agents/)' });
+      healthy = false;
+    }
+  } else {
+    checks.push({ name: 'Agents directory', pass: false, fix: 'Run: guild init (missing .claude/agents/)' });
+    healthy = false;
+  }
+
+  // Check skills
+  const skillsDir = join('.claude', 'skills');
+  if (existsSync(skillsDir)) {
+    const skills = readdirSync(skillsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .filter(d => existsSync(join(skillsDir, d.name, 'SKILL.md')));
+    if (skills.length > 0) {
+      checks.push({ name: `Skills (${skills.length} found)`, pass: true });
+    } else {
+      checks.push({ name: 'Skills', pass: false, fix: 'Run: guild init (no SKILL.md files found in .claude/skills/)' });
+      healthy = false;
+    }
+  } else {
+    checks.push({ name: 'Skills directory', pass: false, fix: 'Run: guild init (missing .claude/skills/)' });
+    healthy = false;
+  }
+
+  // Check CLAUDE.md
+  if (existsSync('CLAUDE.md')) {
+    checks.push({ name: 'CLAUDE.md', pass: true });
+  } else {
+    checks.push({ name: 'CLAUDE.md', pass: false, fix: 'Run: guild init (creates CLAUDE.md with project instructions)' });
+    healthy = false;
+  }
+
+  // Check PROJECT.md
+  if (existsSync('PROJECT.md')) {
+    checks.push({ name: 'PROJECT.md', pass: true });
+  } else {
+    checks.push({ name: 'PROJECT.md', pass: false, fix: 'Run: guild init (creates PROJECT.md with project identity)' });
+    healthy = false;
+  }
+
+  // Check SESSION.md
+  if (existsSync('SESSION.md')) {
+    checks.push({ name: 'SESSION.md', pass: true });
+  } else {
+    checks.push({ name: 'SESSION.md', pass: false, fix: 'Run: guild init (creates SESSION.md for session tracking)' });
+    healthy = false;
+  }
+
+  // Display results
+  for (const check of checks) {
+    if (check.pass) {
+      p.log.success(`${chalk.green('✓')} ${check.name}`);
+    } else {
+      p.log.error(`${chalk.red('✗')} ${check.name}`);
+      p.log.info(chalk.gray(`  Fix: ${check.fix}`));
+    }
+  }
+
+  const passed = checks.filter(c => c.pass).length;
+  const total = checks.length;
+
+  if (healthy) {
+    p.outro(chalk.green(`All checks passed (${passed}/${total})`));
+  } else {
+    p.outro(chalk.red(`${total - passed} issue(s) found (${passed}/${total} passed)`));
+    throw new Error('Guild setup has issues. Run the suggested fixes above.');
+  }
+}


### PR DESCRIPTION
## Summary
- New `guild doctor` command that validates the project Guild setup
- Checks: .claude/ exists, agents present, skills present, CLAUDE.md/PROJECT.md/SESSION.md exist
- Reports issues with actionable fix suggestions
- Exit code 0 if healthy, 1 if issues found
- 5 new tests, all passing

## Test plan
- [x] Unit tests pass (57 total)
- [x] ESLint passes
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)