### PR TITLE
feat: add guild list command (#5)

### DIFF
--- a/bin/guild.js
+++ b/bin/guild.js
@@ -78,4 +78,18 @@ program
     }
   });
 
+// guild list
+program
+  .command('list')
+  .description('List installed agents and skills')
+  .action(async () => {
+    try {
+      const { runList } = await import('../src/commands/list.js');
+      await runList();
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  });
+
 program.parse();

--- a/src/commands/__tests__/list.test.js
+++ b/src/commands/__tests__/list.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('runList', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-list-'));
+    originalCwd = process.cwd();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should list agents and skills with descriptions', async () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'skills', 'build-feature'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'agents', 'advisor.md'),
+      '---\nname: advisor\ndescription: "Strategic advisor"\n---\n# Advisor'
+    );
+    writeFileSync(
+      join(tempDir, '.claude', 'skills', 'build-feature', 'SKILL.md'),
+      '---\nname: build-feature\ndescription: "Full pipeline"\n---\n# Build Feature'
+    );
+
+    process.chdir(tempDir);
+    const { runList } = await import('../list.js');
+    await expect(runList()).resolves.toBeUndefined();
+  });
+
+  it('should handle missing agents directory', async () => {
+    mkdirSync(join(tempDir, '.claude', 'skills', 'test'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'skills', 'test', 'SKILL.md'),
+      '---\nname: test\n---'
+    );
+
+    process.chdir(tempDir);
+    const { runList } = await import('../list.js');
+    await expect(runList()).resolves.toBeUndefined();
+  });
+
+  it('should handle missing skills directory', async () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'agents', 'advisor.md'),
+      '---\nname: advisor\n---'
+    );
+
+    process.chdir(tempDir);
+    const { runList } = await import('../list.js');
+    await expect(runList()).resolves.toBeUndefined();
+  });
+
+  it('should handle empty directories', async () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true });
+
+    process.chdir(tempDir);
+    const { runList } = await import('../list.js');
+    await expect(runList()).resolves.toBeUndefined();
+  });
+
+  it('should handle agents without frontmatter', async () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'agents', 'custom.md'),
+      '# Custom Agent\nNo frontmatter here'
+    );
+
+    process.chdir(tempDir);
+    const { runList } = await import('../list.js');
+    await expect(runList()).resolves.toBeUndefined();
+  });
+});

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,0 +1,82 @@
+/**
+ * list.js — Lists installed agents and skills with descriptions
+ */
+
+import * as p from '@clack/prompts';
+import chalk from 'chalk';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Parses YAML frontmatter from a markdown file content.
+ * Returns an object with key-value pairs from the frontmatter.
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim().replace(/^["']|["']$/g, '');
+    if (key && value) fm[key] = value;
+  }
+  return fm;
+}
+
+export async function runList() {
+  p.intro(chalk.bold.cyan('Guild — Agents & Skills'));
+
+  // List agents
+  const agentsDir = join('.claude', 'agents');
+  p.log.step('Agents');
+
+  if (existsSync(agentsDir)) {
+    const agentFiles = readdirSync(agentsDir).filter(f => f.endsWith('.md')).sort();
+    if (agentFiles.length > 0) {
+      for (const file of agentFiles) {
+        const content = readFileSync(join(agentsDir, file), 'utf8');
+        const fm = parseFrontmatter(content);
+        const name = fm.name || file.replace('.md', '');
+        const desc = fm.description || chalk.gray('(no description)');
+        p.log.info(`  ${chalk.bold(name)} — ${desc}`);
+      }
+    } else {
+      p.log.info(chalk.gray('  No agents found'));
+    }
+  } else {
+    p.log.info(chalk.gray('  No agents directory (.claude/agents/)'));
+  }
+
+  // List skills
+  const skillsDir = join('.claude', 'skills');
+  p.log.step('Skills');
+
+  if (existsSync(skillsDir)) {
+    const skillDirs = readdirSync(skillsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name)
+      .sort();
+    if (skillDirs.length > 0) {
+      for (const dir of skillDirs) {
+        const skillFile = join(skillsDir, dir, 'SKILL.md');
+        if (existsSync(skillFile)) {
+          const content = readFileSync(skillFile, 'utf8');
+          const fm = parseFrontmatter(content);
+          const name = fm.name || dir;
+          const desc = fm.description || chalk.gray('(no description)');
+          p.log.info(`  ${chalk.bold(name)} — ${desc}`);
+        } else {
+          p.log.info(`  ${chalk.bold(dir)} — ${chalk.gray('(missing SKILL.md)')}`);
+        }
+      }
+    } else {
+      p.log.info(chalk.gray('  No skills found'));
+    }
+  } else {
+    p.log.info(chalk.gray('  No skills directory (.claude/skills/)'));
+  }
+
+  p.outro('');
+}


### PR DESCRIPTION
## Summary
- New `guild list` command showing all installed agents and skills
- Parses name and description from YAML frontmatter in .md files
- Grouped output: Agents section then Skills section
- Handles missing directories and missing frontmatter gracefully
- 5 new tests, all passing

## Test plan
- [x] Unit tests pass (57 total)
- [x] ESLint passes
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)