### PR TITLE
docs: add example sessions to skill templates (#6)

### DIFF
--- a/src/templates/skills/build-feature/SKILL.md
+++ b/src/templates/skills/build-feature/SKILL.md
@@ -178,6 +178,21 @@ Task tool with:
   prompt: "Read .claude/agents/developer.md and assume that role. Then: [task description]"
 ```
 
+## Example Session
+
+```text
+User: /build-feature add dark mode toggle to settings page
+
+Phase 1 — Advisor: Approved. Low risk, aligns with UX roadmap.
+Phase 2 — PO: 3 tasks defined with acceptance criteria.
+Phase 3 — Tech Lead: Use CSS variables + context provider pattern.
+Phase 4 — Developer: Implemented ThemeContext, toggle component, CSS vars.
+Phase 5 — Review: Passed. 1 suggestion (memoize context value).
+Phase 6 — QA: All 3 acceptance criteria verified. 0 bugs.
+
+Feature complete. PR ready for merge.
+```
+
 ## Notas
 
 - Si el usuario quiere saltar fases (ej: "ya la evaluo, implementa directo"), permite saltar a Fase 4 pero advierte que se pierde validacion

--- a/src/templates/skills/council/SKILL.md
+++ b/src/templates/skills/council/SKILL.md
@@ -123,6 +123,20 @@ Task tool with:
   prompt: "Read .claude/agents/tech-lead.md and assume that role. Then: [debate question]"
 ```
 
+## Example Session
+
+```text
+User: /council Should we migrate from REST to GraphQL?
+
+Council: Architecture
+
+Tech Lead — Recommends GraphQL for complex queries, keep REST for simple CRUD.
+Advisor — Risk is high mid-project. Suggests incremental adoption.
+Developer — Prefers REST simplicity. GraphQL adds tooling overhead.
+
+Consensus: Incremental adoption. New endpoints in GraphQL, existing stay REST.
+```
+
 ## Notas
 
 - Los agentes deben ser invocados en paralelo para evitar que uno influencie al otro

--- a/src/templates/skills/dev-flow/SKILL.md
+++ b/src/templates/skills/dev-flow/SKILL.md
@@ -55,3 +55,15 @@ Siguiente paso: Ejecuta /build-feature para continuar desde la Fase 3.
 ```
 
 Si no hay feature en curso, informa que no hay pipeline activo y sugiere `/new-feature` o `/build-feature`.
+
+## Example Session
+
+```text
+User: /dev-flow
+
+Current pipeline: build-feature "add user preferences"
+Phase: 4 of 6 — Implementation
+Developer agent active.
+
+Next: Phase 5 — Code Review
+```

--- a/src/templates/skills/guild-specialize/SKILL.md
+++ b/src/templates/skills/guild-specialize/SKILL.md
@@ -121,6 +121,31 @@ git commit -m "chore: enrich CLAUDE.md and agents via guild-specialize"
 
 This ensures enrichment survives any subsequent git operations (stash, checkout, rebase).
 
+## Example Session
+
+```text
+User: /guild-specialize
+
+Guild Specialize analyzing project...
+
+Stack detected:
+- Node.js 20.11.0, TypeScript 5.3.3
+- React 18.2.0, Next.js 14.1.0
+- PostgreSQL via Prisma 5.9.0
+
+Architecture:
+- Next.js App Router (src/app/)
+- API routes in src/app/api/
+- Shared components in src/components/
+
+Agents updated:
+- developer.md: Specialized for Next.js + TypeScript
+- qa.md: Configured for Vitest + Playwright
+- db-migration.md: Configured for Prisma
+
+Run /status to see the full state.
+```
+
 ## Notas importantes
 
 - NUNCA leas archivos `.env` reales — solo `.env.example` o `.env.local`

--- a/src/templates/skills/new-feature/SKILL.md
+++ b/src/templates/skills/new-feature/SKILL.md
@@ -56,6 +56,18 @@ Actualiza SESSION.md con el contexto de la nueva feature:
 - **Tarea en curso:** nombre de la feature
 - **Estado:** Feature iniciada — pendiente de implementacion
 
+## Example Session
+
+```text
+User: /new-feature user-preferences
+
+Branch created: feature/user-preferences
+SESSION.md updated with feature context.
+GitHub Issue #42 created.
+
+Next: Run /build-feature to implement.
+```
+
 ### Paso 4 — GitHub Issue (opcional)
 
 Si el proyecto tiene integracion GitHub configurada en PROJECT.md:

--- a/src/templates/skills/qa-cycle/SKILL.md
+++ b/src/templates/skills/qa-cycle/SKILL.md
@@ -56,6 +56,18 @@ Presenta el resultado:
 
 Actualiza SESSION.md con el resultado del ciclo QA.
 
+## Example Session
+
+```text
+User: /qa-cycle
+
+QA Cycle 1: 2 of 5 criteria pass. Bug: form validation missing on email field.
+Bugfix: Added email regex validation to UserForm component.
+QA Cycle 2: 5 of 5 criteria pass. 0 bugs.
+
+Result: Approved.
+```
+
 ## Subagent Configuration
 
 When spawning QA or Bugfix agents via the Task tool, always use `subagent_type: "general-purpose"`. Guild agent role names are NOT valid Claude Code subagent_types.

--- a/src/templates/skills/review/SKILL.md
+++ b/src/templates/skills/review/SKILL.md
@@ -49,3 +49,18 @@ Presenta el reporte organizado por severidad:
 - Veredicto final: Aprobado / Aprobado con warnings / Bloqueado
 
 Si hay blockers, sugiere corregirlos y ejecutar `/review` de nuevo.
+
+## Example Session
+
+```text
+User: /review
+
+Reviewing diff: 4 files changed, +127 -34
+
+Findings:
+- [Warning] src/api/users.js:45 — No input validation on email parameter
+- [Suggestion] src/utils/format.js:12 — Consider using Intl.DateTimeFormat
+- [Blocker] src/db/queries.js:78 — SQL injection vulnerability in raw query
+
+1 blocker, 1 warning, 1 suggestion.
+```

--- a/src/templates/skills/session-end/SKILL.md
+++ b/src/templates/skills/session-end/SKILL.md
@@ -60,6 +60,20 @@ git commit -m "wip: session paused — [brief description of current state]"
 
 This ensures no work is lost between sessions. Never leave uncommitted changes across session boundaries.
 
+## Example Session
+
+```text
+User: /session-end
+
+Saving session state...
+Task: user-preferences
+Phase: 4 — Implementation (in progress)
+Files modified: 3 files
+WIP committed: wip: session paused — user-preferences phase 4
+
+SESSION.md updated. Safe to close.
+```
+
 ### Paso 4 — Confirmar
 
 Confirma al usuario:

--- a/src/templates/skills/session-start/SKILL.md
+++ b/src/templates/skills/session-start/SKILL.md
@@ -68,3 +68,16 @@ Si no hay tarea en curso, sugiere opciones:
 ### Paso 5 — Actualizar sesion
 
 Actualiza SESSION.md con la fecha actual para registrar que la sesion inicio.
+
+## Example Session
+
+```text
+User: /session-start
+
+Loading context...
+Last session: 2026-02-22
+Task in progress: user-preferences (Phase 4 — Implementation)
+Resumable: feature/user-preferences (wip: phase 3 complete)
+
+Suggested: Continue with /build-feature to resume implementation.
+```

--- a/src/templates/skills/status/SKILL.md
+++ b/src/templates/skills/status/SKILL.md
@@ -62,3 +62,20 @@ Si no hay tarea en curso, sugiere:
 - `/council` para debatir una decision
 
 Si hay tarea en curso, sugiere continuar con el skill apropiado segun el estado.
+
+## Example Session
+
+```text
+User: /status
+
+Guild — MyProject
+Stack: Node.js 20, React 18, PostgreSQL
+
+Session: 2026-02-23
+Task: Implementing user preferences
+State: Phase 4 — Developer implementing
+
+Agents: advisor, product-owner, tech-lead, developer, code-reviewer, qa, bugfix, db-migration
+Skills: guild-specialize, build-feature, new-feature, council, qa-cycle, review, dev-flow,
+  status, session-start, session-end
+```


### PR DESCRIPTION
## Summary
- Added Example Session sections to all 10 SKILL.md templates
- Each example shows realistic input and expected output
- Markdown lint passes with 0 errors

## Skills updated
guild-specialize, build-feature, new-feature, council, qa-cycle, review, dev-flow, status, session-start, session-end

## Test plan
- [x] Markdown lint passes (0 errors)
- [x] ESLint passes
- [x] Tests pass (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)