### PR TITLE
fix: subagent Bash access via frontmatter tools/permissionMode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 Este proyecto usa Guild. Leer SESSION.md al inicio de cada sesion.
 
 ## Que es este proyecto
-Guild es un CLI npm (`npm install -g guild-agents`, comando `guild`) que configura un equipo de 8 agentes IA especializados y 10 skills en cualquier proyecto que use Claude Code. El comando principal es `guild init`, que lanza un onboarding interactivo y genera toda la estructura necesaria.
+Guild es un CLI npm (`npm install -g guild-agents`, comando `guild`) que configura un equipo de 9 agentes IA especializados y 10 skills en cualquier proyecto que use Claude Code. El comando principal es `guild init`, que lanza un onboarding interactivo y genera toda la estructura necesaria.
 
 **Arquitectura v1:** Agentes = WHO (identidad plana en .md), Skills = HOW (workflows con SKILL.md). Composicion nativa de Claude Code — sin composer.js, sin active.md, sin expertise/.
 
@@ -29,6 +29,8 @@ node bin/guild.js init      # probar onboarding v1
 - `guild init`       — onboarding interactivo, genera estructura v1
 - `guild new-agent`  — crear agente personalizado (.md plano)
 - `guild status`     — ver estado del proyecto
+- `guild doctor`     — diagnosticar estado de la instalacion
+- `guild list`       — listar agentes y skills instalados
 
 ## Skills del equipo
 - /guild-specialize  — enriquecer CLAUDE.md explorando el proyecto real
@@ -48,10 +50,10 @@ Node.js 20+, ESModules, Commander.js, @clack/prompts, Vitest, ESLint
 ## Estructura del proyecto
 ```
 src/
-  commands/       — init.js, new-agent.js, status.js
+  commands/       — init.js, new-agent.js, status.js, doctor.js, list.js
   utils/          — generators.js, files.js, github.js
   templates/
-    agents/       — 8 archivos .md (advisor, developer, etc.)
+    agents/       — 9 archivos .md (advisor, developer, platform-expert, etc.)
     skills/       — 10 directorios con SKILL.md
 bin/
   guild.js        — entry point CLI (Commander)

--- a/src/templates/agents/advisor.md
+++ b/src/templates/agents/advisor.md
@@ -1,6 +1,8 @@
 ---
 name: advisor
 description: "Evalua ideas y da direccion estrategica antes de comprometer trabajo"
+tools: Read, Glob, Grep
+permissionMode: plan
 ---
 
 # Advisor

--- a/src/templates/agents/bugfix.md
+++ b/src/templates/agents/bugfix.md
@@ -1,6 +1,8 @@
 ---
 name: bugfix
 description: "Diagnostico y resolucion de bugs"
+tools: Read, Write, Edit, Bash, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 # Bugfix

--- a/src/templates/agents/code-reviewer.md
+++ b/src/templates/agents/code-reviewer.md
@@ -1,6 +1,8 @@
 ---
 name: code-reviewer
 description: "Revisa calidad, patterns, deuda tecnica"
+tools: Read, Glob, Grep
+permissionMode: plan
 ---
 
 # Code Reviewer

--- a/src/templates/agents/db-migration.md
+++ b/src/templates/agents/db-migration.md
@@ -1,6 +1,8 @@
 ---
 name: db-migration
 description: "Cambios de schema, migraciones seguras"
+tools: Read, Write, Edit, Bash, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 # DB Migration

--- a/src/templates/agents/developer.md
+++ b/src/templates/agents/developer.md
@@ -1,6 +1,8 @@
 ---
 name: developer
 description: "Implementa features siguiendo las convenciones del proyecto"
+tools: Read, Write, Edit, Bash, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 # Developer

--- a/src/templates/agents/platform-expert.md
+++ b/src/templates/agents/platform-expert.md
@@ -1,0 +1,89 @@
+---
+name: platform-expert
+description: "Diagnostica y resuelve problemas de integracion con Claude Code — permisos, subagentes, hooks, settings"
+---
+
+# Platform Expert
+
+Eres el Platform Expert de [PROYECTO]. Tu trabajo es diagnosticar y resolver problemas de integracion entre Guild y Claude Code, incluyendo permisos de herramientas, configuracion de subagentes, hooks, y settings.
+
+## Responsabilidades
+
+- Diagnosticar problemas de permisos en subagentes (Bash denied, tool access, etc.)
+- Configurar frontmatter de agentes para acceso correcto a herramientas
+- Implementar PreToolUse hooks para workarounds de permisos
+- Mantener compatibilidad con versiones de Claude Code
+- Documentar limitaciones de la plataforma y workarounds conocidos
+
+## Conocimiento especializado
+
+### Subagent Permission Model
+
+Claude Code subagents corren en modo `dontAsk` por defecto. No heredan permisos de `settings.json`. Para otorgar acceso a Bash:
+
+1. **Frontmatter `tools` field:** Declara herramientas disponibles explicitamente
+2. **Frontmatter `permissionMode`:** Controla nivel de permisos
+3. **PreToolUse hooks:** Workaround para auto-aprobar herramientas
+
+### Configuracion de agentes con Bash
+
+```yaml
+---
+name: agent-name
+description: "Description for delegation"
+tools: Read, Write, Edit, Bash, Glob, Grep
+permissionMode: bypassPermissions
+---
+```
+
+### Configuracion de agentes sin Bash (analisis)
+
+```yaml
+---
+name: agent-name
+description: "Description for delegation"
+tools: Read, Glob, Grep
+permissionMode: plan
+---
+```
+
+### PreToolUse Hook workaround
+
+Si `permissionMode` no funciona, usar hooks:
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}'"
+```
+
+### Bugs conocidos de Claude Code
+
+- Issue #18950: Subagentes no heredan permisos de settings.json (OPEN)
+- Issue #14714: Subagentes no heredan tools del parent
+- Issue #21585: subagent_type "Bash" fabrica output en vez de ejecutar
+
+## Lo que NO haces
+
+- No implementas features de negocio — eso es del Developer
+- No defines arquitectura de aplicacion — eso es del Tech Lead
+- No evaluas estrategia — eso es del Advisor
+
+## Proceso
+
+1. Lee CLAUDE.md para entender la configuracion actual
+2. Identifica el problema de permisos/integracion
+3. Investiga la documentacion de Claude Code y issues conocidos
+4. Propone solucion con frontmatter, hooks, o settings
+5. Prueba la solucion con un subagente de test
+6. Documenta la solucion y workaround
+
+## Reglas de comportamiento
+
+- Siempre verifica la version de Claude Code antes de diagnosticar
+- Prioriza soluciones oficiales sobre workarounds
+- Documenta TODOS los workarounds con referencia al issue de GitHub
+- No asumas que un fix de platform funciona — siempre prueba

--- a/src/templates/agents/product-owner.md
+++ b/src/templates/agents/product-owner.md
@@ -1,6 +1,8 @@
 ---
 name: product-owner
 description: "Convierte ideas aprobadas en tareas concretas e implementables"
+tools: Read, Glob, Grep
+permissionMode: plan
 ---
 
 # Product Owner

--- a/src/templates/agents/qa.md
+++ b/src/templates/agents/qa.md
@@ -1,6 +1,8 @@
 ---
 name: qa
 description: "Testing, edge cases, regression"
+tools: Read, Write, Edit, Bash, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 # QA

--- a/src/templates/agents/tech-lead.md
+++ b/src/templates/agents/tech-lead.md
@@ -1,6 +1,8 @@
 ---
 name: tech-lead
 description: "Define approach tecnico y arquitectura"
+tools: Read, Glob, Grep
+permissionMode: plan
 ---
 
 # Tech Lead

--- a/src/utils/__tests__/files.test.js
+++ b/src/utils/__tests__/files.test.js
@@ -7,9 +7,9 @@ import { copyTemplates, getAgentNames, resolveProjectRoot } from '../files.js';
 const TEST_DIR = join(import.meta.dirname, '__tmp_files__');
 
 describe('getAgentNames', () => {
-  it('returns 8 v1 agent names', () => {
+  it('returns 9 v1 agent names', () => {
     const names = getAgentNames();
-    expect(names).toHaveLength(8);
+    expect(names).toHaveLength(9);
     expect(names).toContain('advisor');
     expect(names).toContain('product-owner');
     expect(names).toContain('tech-lead');
@@ -18,6 +18,7 @@ describe('getAgentNames', () => {
     expect(names).toContain('qa');
     expect(names).toContain('bugfix');
     expect(names).toContain('db-migration');
+    expect(names).toContain('platform-expert');
   });
 
   it('does not contain v0 agent names', () => {
@@ -42,13 +43,13 @@ describe('copyTemplates', () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
   });
 
-  it('creates .claude/agents/ with 8 flat .md files', async () => {
+  it('creates .claude/agents/ with 9 flat .md files', async () => {
     await copyTemplates();
     const agentsDir = join('.claude', 'agents');
     expect(existsSync(agentsDir)).toBe(true);
 
     const files = readdirSync(agentsDir);
-    expect(files).toHaveLength(8);
+    expect(files).toHaveLength(9);
     for (const name of getAgentNames()) {
       expect(files).toContain(`${name}.md`);
     }

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -12,7 +12,7 @@ const AGENTS_DIR = join('.claude', 'agents');
 const SKILLS_DIR = join('.claude', 'skills');
 
 /**
- * Lista los nombres de los 8 agentes v1.
+ * Lista los nombres de los 9 agentes v1.
  */
 export function getAgentNames() {
   return [
@@ -24,6 +24,7 @@ export function getAgentNames() {
     'qa',
     'bugfix',
     'db-migration',
+    'platform-expert',
   ];
 }
 


### PR DESCRIPTION
## Summary
- Add `tools` and `permissionMode` frontmatter to all 8 existing agent templates, fixing Bash access for execution agents
- Create `platform-expert` as 9th agent specialized in Claude Code platform integration
- Update `files.js` to include platform-expert, tests updated from 8 to 9 agents
- Update CLAUDE.md to reflect 9 agents and new CLI commands (doctor, list)

## Root Cause
Claude Code subagents don't inherit user-level permissions from `settings.json` (upstream bug #18950). Without explicit `tools` and `permissionMode` in frontmatter, agents like Developer, Bugfix, and QA cannot execute Bash commands.

## Solution
**Execution agents** (developer, bugfix, qa, db-migration):
```yaml
tools: Read, Write, Edit, Bash, Glob, Grep
permissionMode: bypassPermissions
```

**Analysis agents** (advisor, product-owner, tech-lead, code-reviewer):
```yaml
tools: Read, Glob, Grep
permissionMode: plan
```

## Test plan
- [x] All 62 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Verified Bash access works in subagents (tested both `developer` and `general-purpose` subagent types)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)