### PR TITLE
feat: add guild-re-specialize with protected zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 .claude/settings.json
 .claude/settings.local.json
 .claude/guild/traces/
+.claude/worktrees/
 
 # Internal docs
 SESSION.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,4 +111,5 @@ SESSION.md                            # Session state — persists across conver
 - /session-end       — save state to SESSION.md
 - /tdd               — TDD red-green-refactor discipline
 - /debug             — systematic 4-phase debugging
+- /re-specialize     — incremental re-specialization of auto-generated zones
 - /verify            — evidence-before-claims verification

--- a/SESSION.md
+++ b/SESSION.md
@@ -54,16 +54,16 @@
 
 ## Technical context
 - **Version**: 1.1.0
-- **Tests**: 488 passing (23 files)
+- **Tests**: 497 passing (24 files)
 - **Agents**: 10 templates
-- **Skills**: 14 templates (11 workflow + 3 discipline)
+- **Skills**: 15 templates (12 workflow + 3 discipline)
 - **Node**: v24.12.0 local, CI matrix 20.x/22.x
 
 ## Next steps (Council-approved, Option B — 2026-03-05)
 1. **Create PR** — `/create-pr` for `feature/guild-run-executor` → `develop`
 2. **Bump & publish** — v1.1.0 release
 3. **Import Superpowers skills** — create `/tdd`, `/debug`, `/verify` as Guild templates
-4. **guild-re-specialize (P2)** — protected zones pattern (`<!-- guild:auto-start/end -->`), modify `guild-specialize` to emit markers, build re-specialize skill. See `guild-ideas-eval-and-respecialize.md` Idea 1.
+4. ~~**guild-re-specialize (P2)**~~ — ✅ Done. Zone parser, generators emit markers, guild-specialize updated, re-specialize skill created.
 5. **Workspaces MVP v1.2 (P2)** — `guild-workspace.json`, shared resolution, workspace commands. Needs spec first.
 6. **Skill Evaluation System (P3)** — Component 1 only: trigger test suite. Defer Components 2-4 until skill count > 20. See `guild-ideas-eval-and-respecialize.md` Idea 2.
 7. **Guild Watchdog (P3)** — separate project, defer until v1.2 stable. Consider Watchdog Lite (local, no infra) as intermediate validation. See `ideas/guild-watchdog-spec.md`.

--- a/src/templates/skills/guild-specialize/SKILL.md
+++ b/src/templates/skills/guild-specialize/SKILL.md
@@ -113,6 +113,13 @@ Invoke the Tech Lead agent using Task tool with `model: "opus"` (reasoning tier)
 - **Visible limitations and technical debt**: outdated dependencies, TODOs found
 - **Useful project commands**: detected npm/make/cargo scripts
 
+CLAUDE.md now uses zone markers (`<!-- guild:auto-start:ID -->` / `<!-- guild:auto-end:ID -->`) to delimit auto-generated sections. When enriching:
+
+- Replace content BETWEEN the markers, preserving the markers themselves
+- The following zones exist: `structure`, `architecture`, `conventions`, `env-vars`
+- Do NOT modify content outside of zone markers (user-owned sections)
+- If markers are missing (legacy project), replace `[PENDING: guild-specialize]` placeholders directly
+
 ### Step 4 — Specialize agents
 
 Invoke the Tech Lead agent using Task tool with `model: "sonnet"` (execution tier) to add project-specific context for each agent in `.claude/agents/*.md`:
@@ -126,6 +133,19 @@ Invoke the Tech Lead agent using Task tool with `model: "sonnet"` (execution tie
 - **bugfix.md**: debugging stack, logs, available tools
 - **db-migration.md**: ORM, migration tool, current schema (if applicable)
 - **platform-expert.md**: Claude Code version, known permission bugs, hook configuration
+
+When specializing agents, append a zone at the bottom of each agent file:
+
+```markdown
+<!-- guild:auto-start:agent-context -->
+## Project-Specific Context
+- Stack: [detected stack]
+- Architecture: [detected patterns]
+- Conventions: [detected conventions]
+<!-- guild:auto-end:agent-context -->
+```
+
+This zone allows `guild-re-specialize` to update agent context later without touching the agent's core role definition.
 
 Use the `Task` tool with `model: "sonnet"` to invoke each agent by reading their `.claude/agents/[name].md` if you need a specialized perspective to enrich their configuration.
 

--- a/src/templates/skills/re-specialize/SKILL.md
+++ b/src/templates/skills/re-specialize/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: re-specialize
+description: "Incremental re-specialization — re-scans the project and updates only auto-generated zones in CLAUDE.md and agents"
+user-invocable: true
+workflow:
+  version: 1
+  steps:
+    - id: read-current
+      role: system
+      intent: "Read current CLAUDE.md and agent files to identify existing zones."
+      commands: [cat CLAUDE.md]
+      produces: [current-claude-md, current-agents]
+    - id: explore-project
+      role: system
+      intent: "Scan project for current stack, dependencies, architecture, conventions."
+      commands: [ls -R src/, cat package.json]
+      produces: [detected-stack, detected-architecture, detected-conventions]
+      gate: true
+    - id: check-zones
+      role: system
+      intent: "Check if CLAUDE.md has guild zone markers. If not, offer to inject them."
+      requires: [current-claude-md]
+      produces: [zone-status]
+      gate: true
+    - id: regenerate-zones
+      role: tech-lead
+      intent: "Generate new content for each auto zone based on fresh project scan. Present diff to user."
+      requires: [current-claude-md, detected-stack, detected-architecture, detected-conventions, zone-status]
+      produces: [updated-claude-md, zone-diffs]
+      model-tier: reasoning
+    - id: update-agents
+      role: tech-lead
+      intent: "Update agent-context zones in agent files with fresh project context."
+      requires: [detected-stack, detected-architecture, detected-conventions]
+      produces: [updated-agents]
+      model-tier: execution
+    - id: confirm
+      role: system
+      intent: "Present summary of changes and get user confirmation."
+      requires: [zone-diffs, updated-agents]
+      produces: [confirmation]
+      gate: true
+    - id: commit
+      role: system
+      intent: "Commit re-specialized files."
+      commands: [git add CLAUDE.md .claude/agents/*.md, git commit -m "chore: re-specialize via guild-re-specialize"]
+      requires: [updated-claude-md, updated-agents, confirmation]
+      produces: [re-specialize-commit]
+---
+
+# Re-Specialize
+
+Incrementally updates auto-generated content in CLAUDE.md and agent files
+without touching user customizations. Uses protected zone markers to identify
+what can be safely regenerated.
+
+## When to use
+
+- When project dependencies have changed (new framework, updated versions)
+- When architecture has evolved (new patterns, restructured folders)
+- When agents need refreshed context about the project
+- Periodically to keep CLAUDE.md in sync with the actual codebase
+
+## Process
+
+### Step 1 -- Read current state
+
+Read CLAUDE.md and all agent files in `.claude/agents/`:
+
+- Identify existing zone markers (`<!-- guild:auto-start:ID -->` / `<!-- guild:auto-end:ID -->`)
+- Note which zones exist and their current content
+- Identify any user customizations outside of zones
+
+### Step 2 -- Explore the project
+
+Same exploration as guild-specialize:
+
+- Scan dependency files for current stack and versions
+- Analyze project structure and architecture patterns
+- Detect code conventions from linter/formatter configs
+- Check environment variable examples
+
+### Step 3 -- Check zone markers
+
+If CLAUDE.md has zone markers, proceed to regeneration.
+
+If CLAUDE.md does NOT have zone markers (legacy project):
+
+- Offer to inject markers around the auto-generated sections
+- Show the user where markers would be placed
+- Require explicit confirmation before modifying
+- If user declines, abort gracefully
+
+### Step 4 -- Regenerate zone content
+
+Invoke the Tech Lead agent using Task tool with `model: "opus"` (reasoning tier):
+
+- Generate fresh content for each zone based on the project scan
+- Compare new content with existing zone content
+- Present a diff for each zone to the user
+- Only replace zones where content has actually changed
+
+Zones to regenerate:
+
+| Zone ID        | Content                                    |
+|----------------|--------------------------------------------|
+| `structure`    | Project folder structure with descriptions |
+| `architecture` | Architecture patterns and design decisions |
+| `conventions`  | Code conventions from linter/formatter     |
+| `env-vars`     | Environment variables from .env.example    |
+
+### Step 5 -- Update agent context
+
+Invoke the Tech Lead agent using Task tool with `model: "sonnet"` (execution tier):
+
+- For each agent in `.claude/agents/*.md`, update the `agent-context` zone
+- If no `agent-context` zone exists, append one at the bottom
+- Preserve everything outside the zone (role definition, process, rules)
+
+### Step 6 -- Confirm changes
+
+Present a summary:
+
+```text
+Re-specialization complete for [project-name]
+
+Zones updated:
+- structure: [changed/unchanged]
+- architecture: [changed/unchanged]
+- conventions: [changed/unchanged]
+- env-vars: [changed/unchanged]
+
+Agents updated: [count] of [total]
+
+Review the changes above. Confirm to commit.
+```
+
+### Step 7 -- Commit
+
+Commit all changes as an atomic commit:
+
+```bash
+git add CLAUDE.md .claude/agents/*.md
+git commit -m "chore: re-specialize via guild-re-specialize"
+```
+
+## Important Notes
+
+- NEVER modify content outside of zone markers
+- NEVER read real `.env` files -- only `.env.example`
+- If a zone's content hasn't changed, skip it (no-op)
+- Present diffs before applying changes
+- User confirmation is required before committing

--- a/src/utils/__tests__/files.test.js
+++ b/src/utils/__tests__/files.test.js
@@ -45,7 +45,7 @@ describe('getSkillNames', () => {
   it('reads skill names from the templates directory', () => {
     const names = getSkillNames();
     // Should match the directories in src/templates/skills/
-    expect(names).toHaveLength(14);
+    expect(names).toHaveLength(15);
     expect(names).toContain('build-feature');
     expect(names).toContain('council');
     expect(names).toContain('create-pr');
@@ -54,6 +54,7 @@ describe('getSkillNames', () => {
     expect(names).toContain('guild-specialize');
     expect(names).toContain('new-feature');
     expect(names).toContain('qa-cycle');
+    expect(names).toContain('re-specialize');
     expect(names).toContain('review');
     expect(names).toContain('session-end');
     expect(names).toContain('session-start');

--- a/src/utils/__tests__/generators.test.js
+++ b/src/utils/__tests__/generators.test.js
@@ -102,14 +102,25 @@ describe('generateClaudeMd', () => {
     expect(content).toContain('SESSION.md');
   });
 
-  it('includes exactly 2 placeholders for guild-specialize', async () => {
+  it('wraps auto-generated sections with guild zone markers', async () => {
     await generateClaudeMd(makeProjectData());
     const content = readFileSync('CLAUDE.md', 'utf8');
-    const matches = content.match(/\[PENDING: guild-specialize\]/g);
-    expect(matches).toHaveLength(2);
-    // Placeholders only in Project structure and Architecture patterns
-    expect(content).toContain('## Project structure\n[PENDING: guild-specialize]');
-    expect(content).toContain('## Architecture patterns\n[PENDING: guild-specialize]');
+    expect(content).toContain('<!-- guild:auto-start:structure -->');
+    expect(content).toContain('<!-- guild:auto-end:structure -->');
+    expect(content).toContain('<!-- guild:auto-start:architecture -->');
+    expect(content).toContain('<!-- guild:auto-end:architecture -->');
+    expect(content).toContain('<!-- guild:auto-start:conventions -->');
+    expect(content).toContain('<!-- guild:auto-end:conventions -->');
+    expect(content).toContain('<!-- guild:auto-start:env-vars -->');
+    expect(content).toContain('<!-- guild:auto-end:env-vars -->');
+  });
+
+  it('does not wrap user-owned sections with markers', async () => {
+    await generateClaudeMd(makeProjectData());
+    const content = readFileSync('CLAUDE.md', 'utf8');
+    expect(content).not.toContain('guild:auto-start:global-rules');
+    expect(content).not.toContain('guild:auto-start:subagent-rules');
+    expect(content).not.toContain('guild:auto-start:skills');
   });
 
   it('lists skills instead of slash commands', async () => {

--- a/src/utils/__tests__/zones.test.js
+++ b/src/utils/__tests__/zones.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { wrapZone, extractZones, replaceZone } from '../zones.js';
+
+describe('wrapZone', () => {
+  it('wraps content with start and end markers', () => {
+    const result = wrapZone('stack', '## Stack\n- Node.js 24');
+    expect(result).toBe(
+      '<!-- guild:auto-start:stack -->\n## Stack\n- Node.js 24\n<!-- guild:auto-end:stack -->'
+    );
+  });
+
+  it('trims trailing newline from content before wrapping', () => {
+    const result = wrapZone('arch', 'content\n');
+    expect(result).toBe(
+      '<!-- guild:auto-start:arch -->\ncontent\n<!-- guild:auto-end:arch -->'
+    );
+  });
+});
+
+describe('extractZones', () => {
+  it('extracts a single zone from content', () => {
+    const content = 'before\n<!-- guild:auto-start:stack -->\n## Stack\n- Node\n<!-- guild:auto-end:stack -->\nafter';
+    const zones = extractZones(content);
+    expect(zones.has('stack')).toBe(true);
+    expect(zones.get('stack').content).toBe('## Stack\n- Node');
+  });
+
+  it('extracts multiple zones', () => {
+    const content = [
+      '<!-- guild:auto-start:stack -->', 'stack content', '<!-- guild:auto-end:stack -->',
+      'user content',
+      '<!-- guild:auto-start:arch -->', 'arch content', '<!-- guild:auto-end:arch -->',
+    ].join('\n');
+    const zones = extractZones(content);
+    expect(zones.size).toBe(2);
+    expect(zones.get('stack').content).toBe('stack content');
+    expect(zones.get('arch').content).toBe('arch content');
+  });
+
+  it('returns empty map when no zones exist', () => {
+    const zones = extractZones('plain content with no markers');
+    expect(zones.size).toBe(0);
+  });
+
+  it('skips zones with missing end marker', () => {
+    const content = 'before\n<!-- guild:auto-start:broken -->\nsome content\nafter';
+    const zones = extractZones(content);
+    expect(zones.size).toBe(0);
+  });
+});
+
+describe('replaceZone', () => {
+  it('replaces zone content while preserving markers', () => {
+    const content = 'before\n<!-- guild:auto-start:stack -->\nold\n<!-- guild:auto-end:stack -->\nafter';
+    const result = replaceZone(content, 'stack', 'new content');
+    expect(result).toBe('before\n<!-- guild:auto-start:stack -->\nnew content\n<!-- guild:auto-end:stack -->\nafter');
+  });
+
+  it('returns content unchanged when zone not found', () => {
+    const content = 'no zones here';
+    const result = replaceZone(content, 'missing', 'new');
+    expect(result).toBe(content);
+  });
+});

--- a/src/utils/generators.js
+++ b/src/utils/generators.js
@@ -3,6 +3,7 @@
  */
 
 import { writeFileSync } from 'fs';
+import { wrapZone } from './zones.js';
 
 /**
  * Generates PROJECT.md with the onboarding data.
@@ -105,19 +106,16 @@ This project uses Guild. Read SESSION.md at the start of each session.
 ${data.stack}
 
 ## Project structure
-[PENDING: guild-specialize]
-
-docs/
-  specs/                              # Design documents (SDD specs)
+${wrapZone('structure', '[PENDING: guild-specialize]\n\ndocs/\n  specs/                              # Design documents (SDD specs)')}
 
 ## Code conventions
-${inferCodeConventions(data.type, data.stack)}
+${wrapZone('conventions', inferCodeConventions(data.type, data.stack))}
 
 ## Architecture patterns
-[PENDING: guild-specialize]
+${wrapZone('architecture', '[PENDING: guild-specialize]')}
 
 ## Environment variables
-${inferEnvVars(data.type, data.stack)}
+${wrapZone('env-vars', inferEnvVars(data.type, data.stack))}
 
 ## Global rules
 - Do not implement without an approved plan

--- a/src/utils/zones.js
+++ b/src/utils/zones.js
@@ -1,0 +1,39 @@
+const MARKER_START = 'guild:auto-start';
+const MARKER_END = 'guild:auto-end';
+
+export function wrapZone(zoneId, content) {
+  const trimmed = content.endsWith('\n') ? content.slice(0, -1) : content;
+  return `<!-- ${MARKER_START}:${zoneId} -->\n${trimmed}\n<!-- ${MARKER_END}:${zoneId} -->`;
+}
+
+export function extractZones(content) {
+  const zones = new Map();
+  const startPattern = /^<!-- guild:auto-start:(\S+) -->$/gm;
+  let match;
+
+  while ((match = startPattern.exec(content)) !== null) {
+    const zoneId = match[1];
+    const contentStart = match.index + match[0].length + 1; // +1 for newline
+    const endMarker = `<!-- ${MARKER_END}:${zoneId} -->`;
+    const endIndex = content.indexOf(endMarker, contentStart);
+    if (endIndex === -1) continue;
+
+    zones.set(zoneId, {
+      start: match.index,
+      end: endIndex + endMarker.length,
+      content: content.slice(contentStart, endIndex - 1), // -1 to trim newline before end marker
+    });
+  }
+
+  return zones;
+}
+
+export function replaceZone(content, zoneId, newContent) {
+  const zones = extractZones(content);
+  if (!zones.has(zoneId)) return content;
+
+  const zone = zones.get(zoneId);
+  const before = content.slice(0, zone.start);
+  const after = content.slice(zone.end);
+  return before + wrapZone(zoneId, newContent) + after;
+}


### PR DESCRIPTION
## Summary

- Add zone parser utility (`src/utils/zones.js`) with `wrapZone`, `extractZones`, `replaceZone` for managing auto-generated content markers
- Update `generateClaudeMd` to emit `<!-- guild:auto-start:ID -->` / `<!-- guild:auto-end:ID -->` markers on 4 auto-generated sections (structure, architecture, conventions, env-vars)
- Update `guild-specialize` skill to preserve zone markers when enriching CLAUDE.md and append `agent-context` zones to agents
- Add new `/re-specialize` skill for incremental re-specialization that only touches auto-generated zones

## Changes

- 9 files changed, +304 -17
- New: `src/utils/zones.js` (zone parser), `src/utils/__tests__/zones.test.js` (8 tests)
- New: `src/templates/skills/re-specialize/SKILL.md` (skill template)
- Modified: `generators.js`, `generators.test.js`, `guild-specialize/SKILL.md`, `files.test.js`, `CLAUDE.md`, `SESSION.md`

## Test plan

- [x] Tests: 497 passing (24 files)
- [x] Lint: 0 errors (ESLint + markdownlint)
- [x] Zone parser: 8 tests covering wrap/extract/replace + edge cases
- [x] Generator markers: 2 new tests verifying zone emission
- [x] Skill count: updated 14 → 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)