### PR TITLE
feat: add Guild Workspaces MVP v1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ SESSION.md                            # Session state — persists across conver
 - `npm run lint:js` — ESLint only
 - `npm run lint:md` — markdownlint only
 - `npm run dev` — run CLI locally (`node bin/guild.js`)
+- `guild workspace init <name> <members...>` — create a workspace
+- `guild workspace add <path>` — add a member repo
+- `guild workspace status` — show workspace members and state
 
 ## CI/CD
 - **CI** (`.github/workflows/ci.yml`): lint + test on push/PR to develop/main, matrix Node 20.x/22.x, security audit

--- a/SESSION.md
+++ b/SESSION.md
@@ -54,7 +54,7 @@
 
 ## Technical context
 - **Version**: 1.1.0
-- **Tests**: 497 passing (24 files)
+- **Tests**: 518 passing (26 files)
 - **Agents**: 10 templates
 - **Skills**: 15 templates (12 workflow + 3 discipline)
 - **Node**: v24.12.0 local, CI matrix 20.x/22.x
@@ -64,6 +64,6 @@
 2. **Bump & publish** — v1.1.0 release
 3. **Import Superpowers skills** — create `/tdd`, `/debug`, `/verify` as Guild templates
 4. ~~**guild-re-specialize (P2)**~~ — ✅ Done. Zone parser, generators emit markers, guild-specialize updated, re-specialize skill created.
-5. **Workspaces MVP v1.2 (P2)** — `guild-workspace.json`, shared resolution, workspace commands. Needs spec first.
+5. ~~**Workspaces MVP v1.2 (P2)**~~ — ✅ Done. workspace.js resolver, context generator, CLI commands (init/add/status), workspace-aware init, CLAUDE.md context injection.
 6. **Skill Evaluation System (P3)** — Component 1 only: trigger test suite. Defer Components 2-4 until skill count > 20. See `guild-ideas-eval-and-respecialize.md` Idea 2.
 7. **Guild Watchdog (P3)** — separate project, defer until v1.2 stable. Consider Watchdog Lite (local, no infra) as intermediate validation. See `ideas/guild-watchdog-spec.md`.

--- a/bin/guild.js
+++ b/bin/guild.js
@@ -168,4 +168,61 @@ logsCmd
     }
   });
 
+// guild workspace
+const workspaceCmd = program
+  .command('workspace')
+  .description('Manage multi-repo workspaces');
+
+// guild workspace init
+workspaceCmd
+  .command('init')
+  .description('Initialize a workspace in the current directory')
+  .argument('<name>', 'Workspace name')
+  .argument('<members...>', 'Paths to member repos (e.g., ./backend ./frontend)')
+  .action(async (name, members) => {
+    try {
+      const { createWorkspaceFile } = await import('../src/commands/workspace.js');
+      await createWorkspaceFile(name, members);
+      console.log(`Workspace "${name}" created with ${members.length} member(s).`);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  });
+
+// guild workspace add
+workspaceCmd
+  .command('add')
+  .description('Add a member repo to the workspace')
+  .argument('<path>', 'Path to the member repo')
+  .action(async (memberPath) => {
+    try {
+      const { addWorkspaceMember } = await import('../src/commands/workspace.js');
+      await addWorkspaceMember(memberPath);
+      console.log(`Added "${memberPath}" to workspace.`);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  });
+
+// guild workspace status
+workspaceCmd
+  .command('status')
+  .description('Show workspace members and their state')
+  .action(async () => {
+    try {
+      const { getWorkspaceStatus } = await import('../src/commands/workspace.js');
+      const status = await getWorkspaceStatus();
+      console.log(`Workspace: ${status.name}`);
+      for (const m of status.members) {
+        const state = m.initialized ? 'initialized' : 'not initialized';
+        console.log(`  ${m.name} (${m.path}) — ${state}`);
+      }
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  });
+
 program.parse();

--- a/src/commands/__tests__/workspace.test.js
+++ b/src/commands/__tests__/workspace.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, realpathSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('guild workspace init', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'guild-ws-cmd-')));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates guild-workspace.json with given name and members', async () => {
+    const { createWorkspaceFile } = await import('../workspace.js');
+    await createWorkspaceFile('my-product', ['./backend', './frontend']);
+    expect(existsSync('guild-workspace.json')).toBe(true);
+    const config = JSON.parse(readFileSync('guild-workspace.json', 'utf8'));
+    expect(config.name).toBe('my-product');
+    expect(config.members).toHaveLength(2);
+    expect(config.members[0].path).toBe('./backend');
+    expect(config.members[1].path).toBe('./frontend');
+  });
+
+  it('creates .guild/agents and .guild/skills directories', async () => {
+    const { createWorkspaceFile } = await import('../workspace.js');
+    await createWorkspaceFile('test', ['./app']);
+    expect(existsSync(join('.guild', 'agents'))).toBe(true);
+    expect(existsSync(join('.guild', 'skills'))).toBe(true);
+  });
+
+  it('derives member name from path', async () => {
+    const { createWorkspaceFile } = await import('../workspace.js');
+    await createWorkspaceFile('test', ['./my-backend']);
+    const config = JSON.parse(readFileSync('guild-workspace.json', 'utf8'));
+    expect(config.members[0].name).toBe('my-backend');
+  });
+});
+
+describe('guild workspace add', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'guild-ws-cmd-')));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('adds a member to existing workspace', async () => {
+    const { createWorkspaceFile, addWorkspaceMember } = await import('../workspace.js');
+    await createWorkspaceFile('test', ['./api']);
+    await addWorkspaceMember('./web');
+    const config = JSON.parse(readFileSync('guild-workspace.json', 'utf8'));
+    expect(config.members).toHaveLength(2);
+    expect(config.members[1].name).toBe('web');
+  });
+
+  it('throws when no workspace exists', async () => {
+    const { addWorkspaceMember } = await import('../workspace.js');
+    await expect(addWorkspaceMember('./web')).rejects.toThrow('No workspace found');
+  });
+
+  it('throws when member already exists', async () => {
+    const { createWorkspaceFile, addWorkspaceMember } = await import('../workspace.js');
+    await createWorkspaceFile('test', ['./api']);
+    await expect(addWorkspaceMember('./api')).rejects.toThrow('already a member');
+  });
+});
+
+describe('guild workspace status', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'guild-ws-cmd-')));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns workspace info with member status', async () => {
+    const { createWorkspaceFile, getWorkspaceStatus } = await import('../workspace.js');
+    await createWorkspaceFile('my-product', ['./backend', './frontend']);
+    mkdirSync(join('backend', '.claude'), { recursive: true });
+
+    const status = await getWorkspaceStatus();
+    expect(status.name).toBe('my-product');
+    expect(status.members).toHaveLength(2);
+    expect(status.members[0].initialized).toBe(true);
+    expect(status.members[1].initialized).toBe(false);
+  });
+});

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -14,10 +14,17 @@ import chalk from 'chalk';
 import { existsSync } from 'fs';
 import { generateProjectMd, generateSessionMd, generateClaudeMd } from '../utils/generators.js';
 import { copyTemplates, getAgentNames, getSkillNames } from '../utils/files.js';
+import { loadWorkspace } from '../utils/workspace.js';
 
 export async function runInit() {
   console.log('');
   p.intro(chalk.bold.cyan('Guild v1 — New project'));
+
+  // Detect workspace membership
+  const workspace = loadWorkspace();
+  if (workspace) {
+    p.log.info(chalk.gray(`Workspace detected: ${workspace.name} (${workspace.root})`));
+  }
 
   // Check for existing installation
   if (existsSync('.claude/agents')) {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -114,7 +114,7 @@ export async function runInit() {
   try {
     await copyTemplates();
     spinner.message('Generating CLAUDE.md...');
-    await generateClaudeMd(projectData);
+    await generateClaudeMd(projectData, workspace, name);
 
     spinner.message('Generating PROJECT.md...');
     await generateProjectMd(projectData);

--- a/src/commands/workspace.js
+++ b/src/commands/workspace.js
@@ -1,0 +1,57 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { basename, join } from 'path';
+import { findWorkspaceRoot } from '../utils/workspace.js';
+
+const WORKSPACE_FILE = 'guild-workspace.json';
+
+export async function createWorkspaceFile(name, memberPaths) {
+  const members = memberPaths.map(p => ({
+    name: basename(p),
+    path: p,
+  }));
+
+  const config = {
+    name,
+    members,
+    shared: {
+      agents: '.guild/agents',
+      skills: '.guild/skills',
+    },
+  };
+
+  writeFileSync(WORKSPACE_FILE, JSON.stringify(config, null, 2) + '\n', 'utf8');
+  mkdirSync(join('.guild', 'agents'), { recursive: true });
+  mkdirSync(join('.guild', 'skills'), { recursive: true });
+}
+
+export async function addWorkspaceMember(memberPath) {
+  const root = findWorkspaceRoot();
+  if (!root) throw new Error('No workspace found. Run `guild workspace init` first.');
+
+  const filePath = join(root, WORKSPACE_FILE);
+  const config = JSON.parse(readFileSync(filePath, 'utf8'));
+  const name = basename(memberPath);
+
+  if (config.members.some(m => m.path === memberPath || m.name === name)) {
+    throw new Error(`"${name}" is already a member of this workspace.`);
+  }
+
+  config.members.push({ name, path: memberPath });
+  writeFileSync(filePath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+}
+
+export async function getWorkspaceStatus() {
+  const root = findWorkspaceRoot();
+  if (!root) throw new Error('No workspace found. Run `guild workspace init` first.');
+
+  const filePath = join(root, WORKSPACE_FILE);
+  const config = JSON.parse(readFileSync(filePath, 'utf8'));
+
+  const members = config.members.map(m => {
+    const absPath = join(root, m.path);
+    const initialized = existsSync(join(absPath, '.claude'));
+    return { ...m, absolutePath: absPath, initialized };
+  });
+
+  return { name: config.name, root, members };
+}

--- a/src/commands/workspace.js
+++ b/src/commands/workspace.js
@@ -1,8 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { basename, join } from 'path';
-import { findWorkspaceRoot } from '../utils/workspace.js';
-
-const WORKSPACE_FILE = 'guild-workspace.json';
+import { findWorkspaceRoot, WORKSPACE_FILE } from '../utils/workspace.js';
 
 export async function createWorkspaceFile(name, memberPaths) {
   const members = memberPaths.map(p => ({

--- a/src/utils/__tests__/generators.test.js
+++ b/src/utils/__tests__/generators.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, readFileSync, rmSync, existsSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { generateProjectMd, generateSessionMd, generateClaudeMd, inferCodeConventions, inferEnvVars } from '../generators.js';
 
@@ -165,16 +165,29 @@ describe('generateClaudeMd', () => {
     expect(content).toContain('REDIS_URL');
   });
 
-  it('injects workspace context when workspace data is provided', async () => {
-    await generateClaudeMd(makeProjectData(), {
+  it('injects workspace context when workspace is provided', async () => {
+    // Create a sibling member with PROJECT.md
+    const frontendDir = join(TEST_DIR, '..', 'frontend-test-ws');
+    mkdirSync(frontendDir, { recursive: true });
+    writeFileSync(join(frontendDir, 'PROJECT.md'), '# PROJECT.md\n## Project\n- **Stack:** React, Vite');
+
+    const workspace = {
       name: 'my-product',
-      currentMember: 'backend',
-      otherMembers: [{ name: 'frontend', stack: 'React, Vite' }],
-    });
+      root: join(TEST_DIR, '..'),
+      members: [
+        { name: 'backend', path: './backend', absolutePath: TEST_DIR },
+        { name: 'frontend', path: './frontend-test-ws', absolutePath: frontendDir },
+      ],
+      shared: { agents: '.guild/agents', skills: '.guild/skills' },
+    };
+
+    await generateClaudeMd(makeProjectData(), workspace, 'backend');
     const content = readFileSync('CLAUDE.md', 'utf8');
     expect(content).toContain('## Workspace context');
     expect(content).toContain('my-product');
     expect(content).toContain('frontend');
+
+    rmSync(frontendDir, { recursive: true, force: true });
   });
 
   it('does not inject workspace context when no workspace data', async () => {

--- a/src/utils/__tests__/generators.test.js
+++ b/src/utils/__tests__/generators.test.js
@@ -164,6 +164,24 @@ describe('generateClaudeMd', () => {
     expect(content).toContain('DATABASE_URL');
     expect(content).toContain('REDIS_URL');
   });
+
+  it('injects workspace context when workspace data is provided', async () => {
+    await generateClaudeMd(makeProjectData(), {
+      name: 'my-product',
+      currentMember: 'backend',
+      otherMembers: [{ name: 'frontend', stack: 'React, Vite' }],
+    });
+    const content = readFileSync('CLAUDE.md', 'utf8');
+    expect(content).toContain('## Workspace context');
+    expect(content).toContain('my-product');
+    expect(content).toContain('frontend');
+  });
+
+  it('does not inject workspace context when no workspace data', async () => {
+    await generateClaudeMd(makeProjectData());
+    const content = readFileSync('CLAUDE.md', 'utf8');
+    expect(content).not.toContain('Workspace context');
+  });
 });
 
 describe('inferCodeConventions', () => {

--- a/src/utils/__tests__/workspace.test.js
+++ b/src/utils/__tests__/workspace.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, realpathSync, mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { findWorkspaceRoot, loadWorkspace, resolveWorkspaceAgents } from '../workspace.js';
+import { findWorkspaceRoot, loadWorkspace, resolveWorkspaceAgents, generateWorkspaceContext } from '../workspace.js';
 
 describe('findWorkspaceRoot', () => {
   let testDir;
@@ -140,5 +140,65 @@ describe('resolveWorkspaceAgents', () => {
     const localDir = join(testDir, 'nonexistent');
     const result = resolveWorkspaceAgents(null, localDir);
     expect(result).toEqual([]);
+  });
+});
+
+describe('generateWorkspaceContext', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'guild-ws-test-')));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('generates context section from other members PROJECT.md', () => {
+    const config = {
+      name: 'my-product',
+      members: [
+        { name: 'backend', path: './backend' },
+        { name: 'frontend', path: './frontend' },
+      ],
+      shared: { agents: '.guild/agents', skills: '.guild/skills' },
+    };
+    writeFileSync(join(tempDir, 'guild-workspace.json'), JSON.stringify(config));
+
+    const backendDir = join(tempDir, 'backend');
+    const frontendDir = join(tempDir, 'frontend');
+    mkdirSync(backendDir, { recursive: true });
+    mkdirSync(frontendDir, { recursive: true });
+    writeFileSync(join(backendDir, 'PROJECT.md'), '# PROJECT.md\n## Project\n- **Stack:** Express, PostgreSQL');
+    writeFileSync(join(frontendDir, 'PROJECT.md'), '# PROJECT.md\n## Project\n- **Stack:** React, Vite');
+
+    const workspace = loadWorkspace(tempDir);
+    const result = generateWorkspaceContext(workspace, 'backend');
+
+    expect(result).toContain('## Workspace context');
+    expect(result).toContain('my-product');
+    expect(result).toContain('frontend');
+    expect(result).toContain('React, Vite');
+    expect(result).not.toContain('Express, PostgreSQL');
+  });
+
+  it('returns empty string when workspace is null', () => {
+    const result = generateWorkspaceContext(null, 'backend');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when current member is the only member', () => {
+    const config = {
+      name: 'solo',
+      members: [{ name: 'app', path: './app' }],
+      shared: { agents: '.guild/agents', skills: '.guild/skills' },
+    };
+    writeFileSync(join(tempDir, 'guild-workspace.json'), JSON.stringify(config));
+    mkdirSync(join(tempDir, 'app'), { recursive: true });
+    writeFileSync(join(tempDir, 'app', 'PROJECT.md'), '# PROJECT.md\n## Project\n- **Stack:** Node');
+
+    const workspace = loadWorkspace(tempDir);
+    const result = generateWorkspaceContext(workspace, 'app');
+    expect(result).toBe('');
   });
 });

--- a/src/utils/__tests__/workspace.test.js
+++ b/src/utils/__tests__/workspace.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, realpathSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { findWorkspaceRoot, loadWorkspace, resolveWorkspaceAgents } from '../workspace.js';
+
+describe('findWorkspaceRoot', () => {
+  let testDir;
+
+  beforeEach(() => {
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), 'guild-ws-find-')));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no guild-workspace.json found', () => {
+    const result = findWorkspaceRoot(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('finds workspace root in current directory', () => {
+    writeFileSync(join(testDir, 'guild-workspace.json'), '{}');
+    const result = findWorkspaceRoot(testDir);
+    expect(result).toBe(testDir);
+  });
+
+  it('finds workspace root from nested member directory', () => {
+    writeFileSync(join(testDir, 'guild-workspace.json'), '{}');
+    const nested = join(testDir, 'packages', 'app', 'src');
+    mkdirSync(nested, { recursive: true });
+    const result = findWorkspaceRoot(nested);
+    expect(result).toBe(testDir);
+  });
+});
+
+describe('loadWorkspace', () => {
+  let testDir;
+
+  beforeEach(() => {
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), 'guild-ws-load-')));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no workspace file exists', () => {
+    const result = loadWorkspace(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('loads and parses guild-workspace.json', () => {
+    const config = {
+      name: 'my-workspace',
+      members: [
+        { name: 'app', path: 'packages/app' },
+      ],
+    };
+    writeFileSync(join(testDir, 'guild-workspace.json'), JSON.stringify(config));
+
+    const result = loadWorkspace(testDir);
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('my-workspace');
+    expect(result.root).toBe(testDir);
+    expect(result.members).toHaveLength(1);
+    expect(result.members[0].name).toBe('app');
+  });
+
+  it('resolves member paths relative to workspace root', () => {
+    const config = {
+      members: [
+        { name: 'app', path: 'packages/app' },
+        { name: 'lib', path: 'packages/lib' },
+      ],
+    };
+    writeFileSync(join(testDir, 'guild-workspace.json'), JSON.stringify(config));
+
+    const result = loadWorkspace(testDir);
+    expect(result.members[0].absolutePath).toBe(join(testDir, 'packages', 'app'));
+    expect(result.members[1].absolutePath).toBe(join(testDir, 'packages', 'lib'));
+  });
+});
+
+describe('resolveWorkspaceAgents', () => {
+  let testDir;
+
+  beforeEach(() => {
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), 'guild-ws-agents-')));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns only local agents when no workspace exists', () => {
+    const localDir = join(testDir, 'local-agents');
+    mkdirSync(localDir, { recursive: true });
+    writeFileSync(join(localDir, 'developer.md'), '# Developer');
+
+    const result = resolveWorkspaceAgents(null, localDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('developer');
+    expect(result[0].source).toBe('local');
+  });
+
+  it('merges shared and local agents with local-wins', () => {
+    const sharedDir = join(testDir, 'shared-agents');
+    const localDir = join(testDir, 'local-agents');
+    mkdirSync(sharedDir, { recursive: true });
+    mkdirSync(localDir, { recursive: true });
+
+    writeFileSync(join(sharedDir, 'advisor.md'), '# Shared Advisor');
+    writeFileSync(join(sharedDir, 'developer.md'), '# Shared Developer');
+    writeFileSync(join(localDir, 'developer.md'), '# Local Developer');
+    writeFileSync(join(localDir, 'qa.md'), '# Local QA');
+
+    const workspace = {
+      root: testDir,
+      shared: { agents: 'shared-agents' },
+    };
+
+    const result = resolveWorkspaceAgents(workspace, localDir);
+    expect(result).toHaveLength(3);
+
+    const advisor = result.find(a => a.name === 'advisor');
+    expect(advisor.source).toBe('workspace');
+    expect(advisor.path).toBe(join(sharedDir, 'advisor.md'));
+
+    const developer = result.find(a => a.name === 'developer');
+    expect(developer.source).toBe('local');
+    expect(developer.path).toBe(join(localDir, 'developer.md'));
+
+    const qa = result.find(a => a.name === 'qa');
+    expect(qa.source).toBe('local');
+  });
+
+  it('returns empty array when no agents exist', () => {
+    const localDir = join(testDir, 'nonexistent');
+    const result = resolveWorkspaceAgents(null, localDir);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/utils/generators.js
+++ b/src/utils/generators.js
@@ -96,7 +96,19 @@ export function inferEnvVars(type, stack) {
 /**
  * Generates CLAUDE.md — central document with placeholders for guild-specialize.
  */
-export async function generateClaudeMd(data) {
+export async function generateClaudeMd(data, workspaceInfo = null) {
+  let workspaceSection = '';
+  if (workspaceInfo) {
+    const memberLines = workspaceInfo.otherMembers
+      .map(m => `- **${m.name} stack:** ${m.stack}`)
+      .join('\n');
+    workspaceSection = `\n## Workspace context
+- **Workspace:** ${workspaceInfo.name}
+- **This member:** ${workspaceInfo.currentMember}
+${memberLines}
+`;
+  }
+
   const content = `# ${data.name}
 
 ## Framework
@@ -116,7 +128,7 @@ ${wrapZone('architecture', '[PENDING: guild-specialize]')}
 
 ## Environment variables
 ${wrapZone('env-vars', inferEnvVars(data.type, data.stack))}
-
+${workspaceSection}
 ## Global rules
 - Do not implement without an approved plan
 - Update SESSION.md at the end of each session

--- a/src/utils/generators.js
+++ b/src/utils/generators.js
@@ -4,6 +4,7 @@
 
 import { writeFileSync } from 'fs';
 import { wrapZone } from './zones.js';
+import { generateWorkspaceContext } from './workspace.js';
 
 /**
  * Generates PROJECT.md with the onboarding data.
@@ -96,18 +97,9 @@ export function inferEnvVars(type, stack) {
 /**
  * Generates CLAUDE.md — central document with placeholders for guild-specialize.
  */
-export async function generateClaudeMd(data, workspaceInfo = null) {
-  let workspaceSection = '';
-  if (workspaceInfo) {
-    const memberLines = workspaceInfo.otherMembers
-      .map(m => `- **${m.name} stack:** ${m.stack}`)
-      .join('\n');
-    workspaceSection = `\n## Workspace context
-- **Workspace:** ${workspaceInfo.name}
-- **This member:** ${workspaceInfo.currentMember}
-${memberLines}
-`;
-  }
+export async function generateClaudeMd(data, workspace = null, currentMemberName = null) {
+  const wsContext = generateWorkspaceContext(workspace, currentMemberName);
+  const workspaceSection = wsContext ? `\n${wsContext}\n` : '';
 
   const content = `# ${data.name}
 

--- a/src/utils/workspace.js
+++ b/src/utils/workspace.js
@@ -54,3 +54,29 @@ export function resolveWorkspaceAgents(workspace, localAgentsDir) {
 
   return [...agents.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
+
+export function generateWorkspaceContext(workspace, currentMemberName) {
+  if (!workspace) return '';
+
+  const otherMembers = workspace.members.filter(m => m.name !== currentMemberName);
+  if (otherMembers.length === 0) return '';
+
+  const lines = [
+    '## Workspace context',
+    `- **Workspace:** ${workspace.name}`,
+    `- **Members:** ${workspace.members.map(m => m.name === currentMemberName ? `${m.name} (this)` : m.name).join(', ')}`,
+  ];
+
+  for (const member of otherMembers) {
+    const projectMdPath = join(member.absolutePath, 'PROJECT.md');
+    if (existsSync(projectMdPath)) {
+      const content = readFileSync(projectMdPath, 'utf8');
+      const stackMatch = content.match(/\*\*Stack:\*\*\s*(.+)/);
+      if (stackMatch) {
+        lines.push(`- **${member.name} stack:** ${stackMatch[1].trim()}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/utils/workspace.js
+++ b/src/utils/workspace.js
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 
-const WORKSPACE_FILE = 'guild-workspace.json';
+export const WORKSPACE_FILE = 'guild-workspace.json';
 
 export function findWorkspaceRoot(startDir = process.cwd()) {
   let dir = resolve(startDir);

--- a/src/utils/workspace.js
+++ b/src/utils/workspace.js
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+
+const WORKSPACE_FILE = 'guild-workspace.json';
+
+export function findWorkspaceRoot(startDir = process.cwd()) {
+  let dir = resolve(startDir);
+  while (true) {
+    if (existsSync(join(dir, WORKSPACE_FILE))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+export function loadWorkspace(startDir = process.cwd()) {
+  const root = findWorkspaceRoot(startDir);
+  if (!root) return null;
+
+  const filePath = join(root, WORKSPACE_FILE);
+  const raw = JSON.parse(readFileSync(filePath, 'utf8'));
+
+  return {
+    ...raw,
+    root,
+    members: (raw.members || []).map(m => ({
+      ...m,
+      absolutePath: resolve(root, m.path),
+    })),
+  };
+}
+
+export function resolveWorkspaceAgents(workspace, localAgentsDir) {
+  const agents = new Map();
+
+  if (workspace?.shared?.agents) {
+    const sharedDir = resolve(workspace.root, workspace.shared.agents);
+    if (existsSync(sharedDir)) {
+      for (const file of readdirSync(sharedDir).filter(f => f.endsWith('.md'))) {
+        const name = file.replace('.md', '');
+        agents.set(name, { name, path: join(sharedDir, file), source: 'workspace' });
+      }
+    }
+  }
+
+  if (existsSync(localAgentsDir)) {
+    for (const file of readdirSync(localAgentsDir).filter(f => f.endsWith('.md'))) {
+      const name = file.replace('.md', '');
+      agents.set(name, { name, path: join(localAgentsDir, file), source: 'local' });
+    }
+  }
+
+  return [...agents.values()].sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## Summary

- Add workspace resolver utility (`src/utils/workspace.js`) with `findWorkspaceRoot`, `loadWorkspace`, `resolveWorkspaceAgents`, `generateWorkspaceContext`
- Add workspace CLI commands: `guild workspace init`, `guild workspace add`, `guild workspace status`
- Update `generateClaudeMd` to inject workspace context section when workspace info is provided
- Update `guild init` to detect and report workspace membership
- Multi-repo support via `guild-workspace.json` manifest in parent directory with `.guild/` shared config

## Architecture

- **Parent directory pattern**: `guild-workspace.json` in parent dir lists member repos
- **Merge + local-wins**: shared agents/skills from `.guild/` merged with local `.claude/`, local overrides on name conflict
- **Cross-repo context**: agents see other members' stack info via injected CLAUDE.md section

## Changes

- 10 files changed, +553 -4
- New: `src/utils/workspace.js`, `src/commands/workspace.js` + tests (21 new tests)
- Modified: `generators.js`, `init.js`, `bin/guild.js`, `CLAUDE.md`, `SESSION.md`

## Test plan

- [x] Tests: 518 passing (26 files)
- [x] Lint: 0 errors (ESLint + markdownlint)
- [x] Workspace resolver: 12 tests (find, load, agents merge, context gen)
- [x] Workspace commands: 7 tests (init, add, status)
- [x] Generator workspace: 2 new tests
- [x] Smoke test: `guild workspace --help` shows subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)