### PR TITLE
feat: add guild stats command for token accounting

### DIFF
--- a/bin/guild.js
+++ b/bin/guild.js
@@ -8,6 +8,7 @@
  *   guild status         — view project status
  *   guild doctor         — verify setup and report issues
  *   guild list           — list installed agents and skills
+ *   guild stats          — view token usage and cost stats
  */
 
 import { program } from 'commander';
@@ -162,6 +163,25 @@ logsCmd
     try {
       const { runLogs } = await import('../src/commands/logs.js');
       await runLogs('clean', options);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  });
+
+// guild stats
+program
+  .command('stats')
+  .description('View token usage stats and cost estimates')
+  .option('--period <period>', 'Filter by period: today, week, month, all', 'month')
+  .option('--compare', 'Compare cost across model profiles')
+  .option('--reset', 'Delete all usage history')
+  .option('-f, --force', 'Skip confirmation prompt (for --reset)')
+  .option('--export <format>', 'Export data (csv)')
+  .action(async (options) => {
+    try {
+      const { runStats } = await import('../src/commands/stats.js');
+      await runStats(options);
     } catch (err) {
       console.error(err.message);
       process.exit(1);

--- a/src/commands/__tests__/stats.test.js
+++ b/src/commands/__tests__/stats.test.js
@@ -65,4 +65,35 @@ describe('runStats', () => {
     expect(csv).toContain('timestamp,workflow,agent,tier,model,inputTokens,outputTokens,totalTokens,estimatedCostUSD');
     expect(csv).toContain('build-feature');
   });
+
+  it('shows compare output with multiple entries', async () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature', agent: 'advisor', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 10000, outputTokens: 3000,
+    });
+    recordStep(tempDir, {
+      workflow: 'build-feature', agent: 'developer', tier: 'execution',
+      model: 'claude-sonnet-4-5', inputTokens: 20000, outputTokens: 8000,
+    });
+    recordStep(tempDir, {
+      workflow: 'review', agent: 'reviewer', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 5000, outputTokens: 2000,
+    });
+
+    process.chdir(tempDir);
+    const { runStats } = await import('../stats.js');
+    await expect(runStats({ compare: true })).resolves.toBeUndefined();
+  });
+
+  it('filters by period', async () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature', agent: 'advisor', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 10000, outputTokens: 3000,
+    });
+
+    process.chdir(tempDir);
+    const { runStats } = await import('../stats.js');
+    await expect(runStats({ period: 'today' })).resolves.toBeUndefined();
+    await expect(runStats({ period: 'all' })).resolves.toBeUndefined();
+  });
 });

--- a/src/commands/__tests__/stats.test.js
+++ b/src/commands/__tests__/stats.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { recordStep } from '../../utils/accounting.js';
+
+describe('runStats', () => {
+  let tempDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-stats-'));
+    mkdirSync(join(tempDir, '.claude', 'guild'), { recursive: true });
+    originalCwd = process.cwd();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('shows no-data message when usage.json does not exist', async () => {
+    process.chdir(tempDir);
+    const { runStats } = await import('../stats.js');
+    await expect(runStats({})).resolves.toBeUndefined();
+  });
+
+  it('shows stats when usage data exists', async () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature', agent: 'advisor', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 10000, outputTokens: 3000,
+    });
+
+    process.chdir(tempDir);
+    const { runStats } = await import('../stats.js');
+    await expect(runStats({})).resolves.toBeUndefined();
+  });
+
+  it('resets usage with --reset --force', async () => {
+    recordStep(tempDir, {
+      workflow: 'review', agent: 'reviewer', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 5000, outputTokens: 2000,
+    });
+
+    process.chdir(tempDir);
+    const { runStats } = await import('../stats.js');
+    await runStats({ reset: true, force: true });
+
+    const usagePath = join(tempDir, '.claude', 'guild', 'usage.json');
+    expect(existsSync(usagePath)).toBe(false);
+  });
+
+  it('exports CSV with --export csv', async () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature', agent: 'advisor', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 10000, outputTokens: 3000,
+    });
+
+    process.chdir(tempDir);
+    const { formatCsv } = await import('../stats.js');
+    const { loadUsage } = await import('../../utils/accounting.js');
+    const usage = loadUsage(tempDir);
+    const csv = formatCsv(usage.entries);
+    expect(csv).toContain('timestamp,workflow,agent,tier,model,inputTokens,outputTokens,totalTokens,estimatedCostUSD');
+    expect(csv).toContain('build-feature');
+  });
+});

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -1,0 +1,147 @@
+/**
+ * stats.js — Token usage stats command.
+ */
+
+import * as p from '@clack/prompts';
+import chalk from 'chalk';
+import { existsSync, unlinkSync, copyFileSync } from 'fs';
+import { join } from 'path';
+import { loadUsage, aggregate, estimateWithProfile } from '../utils/accounting.js';
+import { getModelShortName } from '../utils/pricing.js';
+
+const USAGE_PATH = join('.claude', 'guild', 'usage.json');
+
+function fmt(n) {
+  return n.toLocaleString('en-US');
+}
+
+function usd(n) {
+  return `$${n.toFixed(2)}`;
+}
+
+function pct(part, total) {
+  if (total === 0) return '0%';
+  return `${Math.round((part / total) * 100)}%`;
+}
+
+const PERIOD_LABELS = {
+  today: 'Today',
+  week: 'Last 7 days',
+  month: 'Last 30 days',
+  all: 'All time',
+};
+
+export function formatCsv(entries) {
+  const headers = 'timestamp,workflow,agent,tier,model,inputTokens,outputTokens,totalTokens,estimatedCostUSD';
+  const rows = entries.map(e =>
+    `${e.timestamp},${e.workflow},${e.agent},${e.tier},${e.model},${e.inputTokens},${e.outputTokens},${e.totalTokens},${e.estimatedCostUSD.toFixed(6)}`
+  );
+  return [headers, ...rows].join('\n') + '\n';
+}
+
+export async function runStats(options = {}) {
+  const root = process.cwd();
+
+  if (options.reset) {
+    return handleReset(root, options.force);
+  }
+
+  if (options.export === 'csv') {
+    const usage = loadUsage(root);
+    if (usage.entries.length === 0) {
+      console.log('No usage data to export.');
+      return;
+    }
+    process.stdout.write(formatCsv(usage.entries));
+    return;
+  }
+
+  const period = options.period || 'month';
+  const totals = aggregate(root, period);
+
+  p.intro(chalk.bold.cyan(`Guild Usage Stats — ${PERIOD_LABELS[period] || period}`));
+
+  if (totals.totalTokens === 0) {
+    p.log.info('No usage data yet. Token tracking will begin when workflows record usage.');
+    p.outro('');
+    return;
+  }
+
+  p.log.step('Summary');
+  p.log.info(`  Workflows executed:  ${chalk.bold(fmt(totals.workflowCount))}`);
+  p.log.info(`  Total tokens:        ${chalk.bold(fmt(totals.totalTokens))}`);
+  p.log.info(`  Estimated cost:      ${chalk.bold.green(usd(totals.totalCostUSD))}`);
+
+  if (Object.keys(totals.tokensByTier).length > 0) {
+    p.log.step('By tier');
+    for (const [tier, tokens] of Object.entries(totals.tokensByTier)) {
+      p.log.info(`  ${tier.padEnd(12)} ${fmt(tokens).padStart(10)} tok  (${pct(tokens, totals.totalTokens).padStart(4)})`);
+    }
+  }
+
+  if (Object.keys(totals.tokensByModel).length > 0) {
+    p.log.step('By model');
+    for (const [model, tokens] of Object.entries(totals.tokensByModel)) {
+      p.log.info(`  ${getModelShortName(model).padEnd(12)} ${fmt(tokens).padStart(10)} tok`);
+    }
+  }
+
+  if (Object.keys(totals.tokensByWorkflow).length > 0) {
+    p.log.step('Top workflows');
+    const sorted = Object.entries(totals.tokensByWorkflow).sort((a, b) => b[1] - a[1]);
+    for (const [wf, tokens] of sorted) {
+      p.log.info(`  ${wf.padEnd(20)} ${fmt(tokens).padStart(10)} tok`);
+    }
+  }
+
+  if (options.compare) {
+    const usage = loadUsage(root);
+    const filtered = usage.entries;
+    const maxCost = estimateWithProfile(filtered, 'max');
+    const proCost = estimateWithProfile(filtered, 'pro');
+    const allOpusCost = estimateWithProfile(filtered, 'all-opus');
+
+    p.log.step('Profile comparison');
+    p.log.info(`  ${'max'.padEnd(12)} ${usd(maxCost).padStart(10)}    —`);
+    p.log.info(`  ${'pro'.padEnd(12)} ${usd(proCost).padStart(10)}    ${diffLabel(proCost, maxCost)}`);
+    p.log.info(`  ${'all-opus'.padEnd(12)} ${usd(allOpusCost).padStart(10)}    ${diffLabel(allOpusCost, maxCost)}`);
+  }
+
+  p.outro('');
+}
+
+function diffLabel(cost, baseline) {
+  if (baseline === 0) return '';
+  const diff = ((cost - baseline) / baseline) * 100;
+  const sign = diff >= 0 ? '+' : '';
+  return chalk.gray(`${sign}${Math.round(diff)}%`);
+}
+
+async function handleReset(root, force) {
+  const filePath = join(root, USAGE_PATH);
+
+  p.intro(chalk.bold.cyan('Guild — Reset Usage Stats'));
+
+  if (!existsSync(filePath)) {
+    p.log.info('No usage data found. Nothing to reset.');
+    p.outro('');
+    return;
+  }
+
+  if (!force) {
+    const confirmed = await p.confirm({
+      message: 'This will delete all usage history. Continue?',
+      initialValue: false,
+    });
+
+    if (p.isCancel(confirmed) || !confirmed) {
+      p.cancel('Reset cancelled.');
+      return;
+    }
+  }
+
+  copyFileSync(filePath, filePath + '.bak');
+  unlinkSync(filePath);
+  p.log.success(`${chalk.green('✓')} Usage history deleted. Backup saved as usage.json.bak.`);
+  p.outro('');
+}

--- a/src/utils/__tests__/accounting.test.js
+++ b/src/utils/__tests__/accounting.test.js
@@ -8,6 +8,8 @@ import {
   saveUsage,
   recordStep,
   emptyUsage,
+  aggregate,
+  estimateWithProfile,
 } from '../accounting.js';
 
 describe('createEntry', () => {
@@ -117,5 +119,89 @@ describe('persistence', () => {
     expect(usage.totals.tokensByModel['claude-sonnet-4-5']).toBe(28000);
     expect(usage.totals.tokensByTier['reasoning']).toBe(13000);
     expect(usage.totals.tokensByTier['execution']).toBe(28000);
+  });
+});
+
+describe('aggregate', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-agg-'));
+    mkdirSync(join(tempDir, '.claude', 'guild'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns empty totals when no entries', () => {
+    const result = aggregate(tempDir, 'all');
+    expect(result.totalTokens).toBe(0);
+    expect(result.workflowCount).toBe(0);
+  });
+
+  it('aggregate all returns totals across all entries', () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature', agent: 'advisor', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 10000, outputTokens: 3000,
+    });
+    recordStep(tempDir, {
+      workflow: 'review', agent: 'code-reviewer', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 5000, outputTokens: 2000,
+    });
+
+    const result = aggregate(tempDir, 'all');
+    expect(result.totalTokens).toBe(20000);
+    expect(result.workflowCount).toBe(2);
+    expect(result.tokensByWorkflow['build-feature']).toBe(13000);
+    expect(result.tokensByWorkflow['review']).toBe(7000);
+  });
+
+  it('aggregate today filters to current day entries', () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature', agent: 'advisor', tier: 'reasoning',
+      model: 'claude-opus-4-6', inputTokens: 10000, outputTokens: 3000,
+    });
+
+    const result = aggregate(tempDir, 'today');
+    expect(result.totalTokens).toBe(13000);
+  });
+});
+
+describe('estimateWithProfile', () => {
+  it('calculates cost with pro profile (reasoning→sonnet)', () => {
+    const entries = [
+      createEntry({
+        workflow: 'build-feature', agent: 'advisor', tier: 'reasoning',
+        model: 'claude-opus-4-6', inputTokens: 10000, outputTokens: 5000,
+      }),
+    ];
+    // Pro maps reasoning to sonnet: 10000*3/M + 5000*15/M = 0.03 + 0.075 = 0.105
+    const cost = estimateWithProfile(entries, 'pro');
+    expect(cost).toBeCloseTo(0.105, 3);
+  });
+
+  it('calculates cost with max profile (execution→sonnet)', () => {
+    const entries = [
+      createEntry({
+        workflow: 'build-feature', agent: 'developer', tier: 'execution',
+        model: 'claude-sonnet-4-5', inputTokens: 20000, outputTokens: 8000,
+      }),
+    ];
+    // Max maps execution to sonnet: 20000*3/M + 8000*15/M = 0.06 + 0.12 = 0.18
+    const cost = estimateWithProfile(entries, 'max');
+    expect(cost).toBeCloseTo(0.18, 3);
+  });
+
+  it('calculates all-opus cost', () => {
+    const entries = [
+      createEntry({
+        workflow: 'review', agent: 'reviewer', tier: 'execution',
+        model: 'claude-sonnet-4-5', inputTokens: 10000, outputTokens: 5000,
+      }),
+    ];
+    // all-opus: 10000*15/M + 5000*75/M = 0.15 + 0.375 = 0.525
+    const cost = estimateWithProfile(entries, 'all-opus');
+    expect(cost).toBeCloseTo(0.525, 3);
   });
 });

--- a/src/utils/__tests__/accounting.test.js
+++ b/src/utils/__tests__/accounting.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, mkdtempSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  createEntry,
+  loadUsage,
+  saveUsage,
+  recordStep,
+  emptyUsage,
+} from '../accounting.js';
+
+describe('createEntry', () => {
+  it('creates a usage entry with estimated cost', () => {
+    const entry = createEntry({
+      workflow: 'build-feature',
+      agent: 'tech-lead',
+      tier: 'reasoning',
+      model: 'claude-opus-4-6',
+      inputTokens: 10000,
+      outputTokens: 5000,
+    });
+    expect(entry.workflow).toBe('build-feature');
+    expect(entry.agent).toBe('tech-lead');
+    expect(entry.tier).toBe('reasoning');
+    expect(entry.model).toBe('claude-opus-4-6');
+    expect(entry.inputTokens).toBe(10000);
+    expect(entry.outputTokens).toBe(5000);
+    expect(entry.totalTokens).toBe(15000);
+    expect(entry.estimatedCostUSD).toBeCloseTo(0.525, 3);
+    expect(entry.timestamp).toBeDefined();
+  });
+});
+
+describe('persistence', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'guild-accounting-'));
+    mkdirSync(join(tempDir, '.claude', 'guild'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('loadUsage returns empty usage when file does not exist', () => {
+    const usage = loadUsage(tempDir);
+    expect(usage.version).toBe(1);
+    expect(usage.entries).toEqual([]);
+    expect(usage.totals.totalTokens).toBe(0);
+  });
+
+  it('saveUsage creates file and loadUsage reads it back', () => {
+    const usage = emptyUsage();
+    usage.entries.push(createEntry({
+      workflow: 'review',
+      agent: 'code-reviewer',
+      tier: 'reasoning',
+      model: 'claude-opus-4-6',
+      inputTokens: 5000,
+      outputTokens: 2000,
+    }));
+    saveUsage(tempDir, usage);
+
+    const usagePath = join(tempDir, '.claude', 'guild', 'usage.json');
+    expect(existsSync(usagePath)).toBe(true);
+
+    const loaded = loadUsage(tempDir);
+    expect(loaded.entries).toHaveLength(1);
+    expect(loaded.entries[0].workflow).toBe('review');
+  });
+
+  it('recordStep adds entry and updates totals', () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature',
+      agent: 'advisor',
+      tier: 'reasoning',
+      model: 'claude-opus-4-6',
+      inputTokens: 12500,
+      outputTokens: 3200,
+    });
+
+    const usage = loadUsage(tempDir);
+    expect(usage.entries).toHaveLength(1);
+    expect(usage.totals.totalTokens).toBe(15700);
+    expect(usage.totals.totalInputTokens).toBe(12500);
+    expect(usage.totals.totalOutputTokens).toBe(3200);
+    expect(usage.totals.tokensByModel['claude-opus-4-6']).toBe(15700);
+    expect(usage.totals.tokensByTier['reasoning']).toBe(15700);
+    expect(usage.totals.tokensByWorkflow['build-feature']).toBe(15700);
+    expect(usage.totals.workflowCount).toBe(1);
+  });
+
+  it('recordStep accumulates across multiple calls', () => {
+    recordStep(tempDir, {
+      workflow: 'build-feature',
+      agent: 'advisor',
+      tier: 'reasoning',
+      model: 'claude-opus-4-6',
+      inputTokens: 10000,
+      outputTokens: 3000,
+    });
+    recordStep(tempDir, {
+      workflow: 'build-feature',
+      agent: 'developer',
+      tier: 'execution',
+      model: 'claude-sonnet-4-5',
+      inputTokens: 20000,
+      outputTokens: 8000,
+    });
+
+    const usage = loadUsage(tempDir);
+    expect(usage.entries).toHaveLength(2);
+    expect(usage.totals.totalTokens).toBe(41000);
+    expect(usage.totals.tokensByModel['claude-opus-4-6']).toBe(13000);
+    expect(usage.totals.tokensByModel['claude-sonnet-4-5']).toBe(28000);
+    expect(usage.totals.tokensByTier['reasoning']).toBe(13000);
+    expect(usage.totals.tokensByTier['execution']).toBe(28000);
+  });
+});

--- a/src/utils/__tests__/pricing.test.js
+++ b/src/utils/__tests__/pricing.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { estimateCost, getModelShortName, DEFAULT_PRICING } from '../pricing.js';
+
+describe('DEFAULT_PRICING', () => {
+  it('has pricing for opus, sonnet, and haiku', () => {
+    expect(DEFAULT_PRICING['claude-opus-4-6']).toBeDefined();
+    expect(DEFAULT_PRICING['claude-sonnet-4-5']).toBeDefined();
+    expect(DEFAULT_PRICING['claude-haiku-4-5']).toBeDefined();
+  });
+
+  it('each model has input and output prices', () => {
+    for (const model of Object.keys(DEFAULT_PRICING)) {
+      expect(DEFAULT_PRICING[model].input).toBeTypeOf('number');
+      expect(DEFAULT_PRICING[model].output).toBeTypeOf('number');
+    }
+  });
+});
+
+describe('estimateCost', () => {
+  it('calculates cost for known model', () => {
+    // 1000 input tokens of Haiku at $0.80/M = $0.0008
+    // 500 output tokens of Haiku at $4.00/M = $0.002
+    const cost = estimateCost('claude-haiku-4-5', 1000, 500);
+    expect(cost).toBeCloseTo(0.0028, 4);
+  });
+
+  it('calculates cost for opus', () => {
+    // 10000 input at $15/M = $0.15
+    // 5000 output at $75/M = $0.375
+    const cost = estimateCost('claude-opus-4-6', 10000, 5000);
+    expect(cost).toBeCloseTo(0.525, 3);
+  });
+
+  it('returns 0 for unknown model', () => {
+    const cost = estimateCost('unknown-model', 1000, 500);
+    expect(cost).toBe(0);
+  });
+
+  it('returns 0 for zero tokens', () => {
+    const cost = estimateCost('claude-sonnet-4-5', 0, 0);
+    expect(cost).toBe(0);
+  });
+});
+
+describe('getModelShortName', () => {
+  it('returns short names for known models', () => {
+    expect(getModelShortName('claude-opus-4-6')).toBe('Opus');
+    expect(getModelShortName('claude-sonnet-4-5')).toBe('Sonnet');
+    expect(getModelShortName('claude-haiku-4-5')).toBe('Haiku');
+  });
+
+  it('returns model id for unknown models', () => {
+    expect(getModelShortName('gemini-2.5-pro')).toBe('gemini-2.5-pro');
+  });
+});

--- a/src/utils/accounting.js
+++ b/src/utils/accounting.js
@@ -1,0 +1,80 @@
+/**
+ * accounting.js — Token usage recording, persistence, and aggregation.
+ *
+ * Persists usage data to .claude/guild/usage.json.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { estimateCost } from './pricing.js';
+
+const USAGE_PATH = join('.claude', 'guild', 'usage.json');
+
+export function emptyUsage() {
+  return {
+    version: 1,
+    lastUpdated: new Date().toISOString(),
+    entries: [],
+    totals: {
+      totalTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCostUSD: 0,
+      tokensByModel: {},
+      tokensByTier: {},
+      tokensByWorkflow: {},
+      workflowCount: 0,
+    },
+  };
+}
+
+export function createEntry({ workflow, agent, tier, model, inputTokens, outputTokens }) {
+  const totalTokens = inputTokens + outputTokens;
+  return {
+    timestamp: new Date().toISOString(),
+    workflow,
+    agent,
+    tier,
+    model,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    estimatedCostUSD: estimateCost(model, inputTokens, outputTokens),
+  };
+}
+
+export function loadUsage(root) {
+  const filePath = join(root, USAGE_PATH);
+  if (!existsSync(filePath)) return emptyUsage();
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return emptyUsage();
+  }
+}
+
+export function saveUsage(root, usage) {
+  const filePath = join(root, USAGE_PATH);
+  mkdirSync(dirname(filePath), { recursive: true });
+  usage.lastUpdated = new Date().toISOString();
+  writeFileSync(filePath, JSON.stringify(usage, null, 2) + '\n');
+}
+
+function updateTotals(totals, entry) {
+  totals.totalTokens += entry.totalTokens;
+  totals.totalInputTokens += entry.inputTokens;
+  totals.totalOutputTokens += entry.outputTokens;
+  totals.totalCostUSD += entry.estimatedCostUSD;
+  totals.tokensByModel[entry.model] = (totals.tokensByModel[entry.model] || 0) + entry.totalTokens;
+  totals.tokensByTier[entry.tier] = (totals.tokensByTier[entry.tier] || 0) + entry.totalTokens;
+  totals.tokensByWorkflow[entry.workflow] = (totals.tokensByWorkflow[entry.workflow] || 0) + entry.totalTokens;
+  totals.workflowCount += 1;
+}
+
+export function recordStep(root, params) {
+  const usage = loadUsage(root);
+  const entry = createEntry(params);
+  usage.entries.push(entry);
+  updateTotals(usage.totals, entry);
+  saveUsage(root, usage);
+}

--- a/src/utils/accounting.js
+++ b/src/utils/accounting.js
@@ -78,3 +78,62 @@ export function recordStep(root, params) {
   updateTotals(usage.totals, entry);
   saveUsage(root, usage);
 }
+
+const PROFILES = {
+  max: { reasoning: 'claude-opus-4-6', execution: 'claude-sonnet-4-5', routine: 'claude-haiku-4-5' },
+  pro: { reasoning: 'claude-sonnet-4-5', execution: 'claude-sonnet-4-5', routine: 'claude-haiku-4-5' },
+  'all-opus': { reasoning: 'claude-opus-4-6', execution: 'claude-opus-4-6', routine: 'claude-opus-4-6' },
+};
+
+export function aggregate(root, period) {
+  const usage = loadUsage(root);
+  const now = new Date();
+  let cutoff;
+
+  switch (period) {
+    case 'today':
+      cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      break;
+    case 'week':
+      cutoff = new Date(now);
+      cutoff.setDate(cutoff.getDate() - 7);
+      break;
+    case 'month':
+      cutoff = new Date(now);
+      cutoff.setDate(cutoff.getDate() - 30);
+      break;
+    default:
+      cutoff = new Date(0);
+  }
+
+  const filtered = usage.entries.filter(e => new Date(e.timestamp) >= cutoff);
+
+  const totals = {
+    totalTokens: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCostUSD: 0,
+    tokensByModel: {},
+    tokensByTier: {},
+    tokensByWorkflow: {},
+    workflowCount: 0,
+  };
+
+  for (const entry of filtered) {
+    updateTotals(totals, entry);
+  }
+
+  return totals;
+}
+
+export function estimateWithProfile(entries, profileName) {
+  const profile = PROFILES[profileName];
+  if (!profile) return 0;
+
+  let cost = 0;
+  for (const entry of entries) {
+    const model = profile[entry.tier] || entry.model;
+    cost += estimateCost(model, entry.inputTokens, entry.outputTokens);
+  }
+  return cost;
+}

--- a/src/utils/pricing.js
+++ b/src/utils/pricing.js
@@ -1,0 +1,28 @@
+/**
+ * pricing.js — Model pricing table and cost calculation.
+ *
+ * Prices per million tokens (USD).
+ * Source: https://docs.anthropic.com/en/docs/about-claude/models
+ */
+
+export const DEFAULT_PRICING = {
+  'claude-opus-4-6': { input: 15.00, output: 75.00 },
+  'claude-sonnet-4-5': { input: 3.00, output: 15.00 },
+  'claude-haiku-4-5': { input: 0.80, output: 4.00 },
+};
+
+const SHORT_NAMES = {
+  'claude-opus-4-6': 'Opus',
+  'claude-sonnet-4-5': 'Sonnet',
+  'claude-haiku-4-5': 'Haiku',
+};
+
+export function estimateCost(model, inputTokens, outputTokens) {
+  const pricing = DEFAULT_PRICING[model];
+  if (!pricing) return 0;
+  return (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
+}
+
+export function getModelShortName(model) {
+  return SHORT_NAMES[model] || model;
+}


### PR DESCRIPTION
## Summary
- Adds `guild stats` CLI command for tracking token usage and costs across Guild workflow executions
- New modules: `pricing.js` (model cost table), `accounting.js` (usage recording, persistence, aggregation)
- Supports `--period` (today/week/month/all), `--compare` (profile cost comparison), `--reset`, `--export csv`
- Implements P0 roadmap item "Token Accounting / guild stats"

## Changes
- `src/utils/pricing.js` — Model pricing table (Opus/Sonnet/Haiku) with cost calculation
- `src/utils/accounting.js` — Usage recording to `.claude/guild/usage.json`, time-period aggregation, profile comparison (max/pro/all-opus)
- `src/commands/stats.js` — CLI command with formatted output
- `bin/guild.js` — Command registration
- 25 new tests (8 pricing + 11 accounting + 6 stats command)

## Test plan
- [x] Tests: 578 passing (25 new)
- [x] Lint: clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)