### PR TITLE
feat: executor v1.2 — parallel execution and delegation

### DIFF
--- a/src/utils/__tests__/executor.test.js
+++ b/src/utils/__tests__/executor.test.js
@@ -44,13 +44,20 @@ function mockProvider(responses = {}) {
   });
 }
 
-// Stub for buildStepContext — executor imports this from orchestrator-io
 vi.mock('../orchestrator-io.js', async (importOriginal) => {
   const original = await importOriginal();
   return {
     ...original,
     buildStepContext: vi.fn((_step, _plan, _options) => 'mocked context prompt'),
     recordStepTrace: vi.fn(),
+    loadWorkflow: vi.fn(),
+    resolveStepDispatch: vi.fn((step) => ({
+      role: step.role === 'system' ? 'system' : 'agent',
+      tier: step.role === 'system' ? null : 'execution',
+      model: step.role === 'system' ? null : 'claude-sonnet-4-6',
+      fallback: false,
+      agentMetadata: null,
+    })),
   };
 });
 
@@ -198,7 +205,9 @@ describe('execute', () => {
     expect(result.stepStates['gate'].status).toBe('failed');
   });
 
-  it('handles delegation steps by marking passed (v1.1)', async () => {
+  it('handles delegation steps by executing sub-skill', async () => {
+    const { loadWorkflow: mockLoadWorkflow } = await import('../orchestrator-io.js');
+
     const workflow = makeWorkflow([
       makeStep({
         id: 'delegate',
@@ -211,10 +220,17 @@ describe('execute', () => {
     const dispatchMap = makeDispatchMap(plan);
     const provider = mockProvider();
 
+    vi.mocked(mockLoadWorkflow).mockReturnValueOnce({
+      workflow: makeWorkflow([makeStep({ id: 'sub-1', role: 'qa' })]),
+      body: '',
+      name: 'qa-cycle',
+    });
+
     const result = await execute(plan, dispatchMap, { provider });
 
     expect(result.status).toBe('completed');
     expect(result.stepStates['delegate'].status).toBe('passed');
+    expect(provider).toHaveBeenCalledOnce();
   });
 
   it('aborts after MAX_EMPTY_ITERATIONS when no steps are executable', async () => {
@@ -269,5 +285,266 @@ describe('execute', () => {
     expect(result.status).toBe('completed');
     expect(result.stepStates['flaky'].status).toBe('passed');
     expect(provider).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('parallel execution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dispatches parallel steps concurrently', async () => {
+    const workflow = makeWorkflow([
+      makeStep({ id: 'a', role: 'advisor', parallel: ['b', 'c'] }),
+      makeStep({ id: 'b', role: 'developer', parallel: ['a', 'c'] }),
+      makeStep({ id: 'c', role: 'qa', parallel: ['a', 'b'] }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+
+    const inFlight = [];
+    const provider = vi.fn(async (step) => {
+      inFlight.push(step.id);
+      await new Promise(r => { globalThis.setTimeout(r, 10); });
+      return { status: 'passed', output: `done-${step.id}` };
+    });
+
+    const result = await execute(plan, dispatchMap, { provider });
+
+    expect(result.status).toBe('completed');
+    expect(result.stepStates['a'].status).toBe('passed');
+    expect(result.stepStates['b'].status).toBe('passed');
+    expect(result.stepStates['c'].status).toBe('passed');
+    // All 3 should have been started before any finished
+    expect(inFlight).toEqual(['a', 'b', 'c']);
+    expect(provider).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles mixed sequential and parallel groups', async () => {
+    const workflow = makeWorkflow([
+      makeStep({ id: 'seq1', role: 'advisor' }),
+      makeStep({ id: 'par-a', role: 'developer', parallel: ['par-b'] }),
+      makeStep({ id: 'par-b', role: 'qa', parallel: ['par-a'] }),
+      makeStep({ id: 'seq2', role: 'code-reviewer' }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+
+    const callOrder = [];
+    const provider = vi.fn(async (step) => {
+      callOrder.push(step.id);
+      return { status: 'passed', output: 'ok' };
+    });
+
+    const result = await execute(plan, dispatchMap, { provider });
+
+    expect(result.status).toBe('completed');
+    expect(callOrder[0]).toBe('seq1');
+    expect(callOrder.slice(1, 3).sort()).toEqual(['par-a', 'par-b']);
+    expect(callOrder[3]).toBe('seq2');
+  });
+
+  it('failing parallel step does not block other parallel peers', async () => {
+    const workflow = makeWorkflow([
+      makeStep({ id: 'a', role: 'advisor', parallel: ['b'], onFailure: 'continue' }),
+      makeStep({ id: 'b', role: 'developer', parallel: ['a'] }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+
+    const provider = vi.fn(async (step) => {
+      if (step.id === 'a') return { status: 'failed', output: 'boom', error: 'err' };
+      return { status: 'passed', output: 'ok' };
+    });
+
+    const result = await execute(plan, dispatchMap, { provider });
+
+    expect(result.stepStates['a'].status).toBe('failed');
+    expect(result.stepStates['b'].status).toBe('passed');
+    expect(provider).toHaveBeenCalledTimes(2);
+  });
+
+  it('fires onStepStart and onStepEnd for each parallel step', async () => {
+    const workflow = makeWorkflow([
+      makeStep({ id: 'a', role: 'advisor', parallel: ['b'] }),
+      makeStep({ id: 'b', role: 'developer', parallel: ['a'] }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+    const provider = mockProvider();
+
+    const starts = [];
+    const ends = [];
+
+    await execute(plan, dispatchMap, {
+      provider,
+      onStepStart: (step) => starts.push(step.id),
+      onStepEnd: (step) => ends.push(step.id),
+    });
+
+    expect(starts.sort()).toEqual(['a', 'b']);
+    expect(ends.sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('delegation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('executes delegated sub-skill to completion', async () => {
+    const { loadWorkflow: mockLoadWorkflow } = await import('../orchestrator-io.js');
+
+    const workflow = makeWorkflow([
+      makeStep({
+        id: 'delegate',
+        role: 'system',
+        intent: 'Run QA cycle',
+        delegatesTo: 'qa-cycle',
+      }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+
+    // Mock loadWorkflow to return a simple sub-skill
+    vi.mocked(mockLoadWorkflow).mockReturnValueOnce({
+      workflow: makeWorkflow([
+        makeStep({ id: 'sub-1', role: 'qa' }),
+        makeStep({ id: 'sub-2', role: 'bugfix' }),
+      ]),
+      body: 'sub-skill body',
+      name: 'qa-cycle',
+    });
+
+    const provider = mockProvider();
+
+    const result = await execute(plan, dispatchMap, { provider });
+
+    expect(result.status).toBe('completed');
+    expect(result.stepStates['delegate'].status).toBe('passed');
+    expect(provider).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails delegation step when sub-skill fails', async () => {
+    const { loadWorkflow: mockLoadWorkflow } = await import('../orchestrator-io.js');
+
+    const workflow = makeWorkflow([
+      makeStep({
+        id: 'delegate',
+        role: 'system',
+        intent: 'Run QA cycle',
+        delegatesTo: 'qa-cycle',
+        onFailure: 'abort',
+      }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+
+    vi.mocked(mockLoadWorkflow).mockReturnValueOnce({
+      workflow: makeWorkflow([
+        makeStep({ id: 'sub-1', role: 'qa', onFailure: 'abort' }),
+      ]),
+      body: '',
+      name: 'qa-cycle',
+    });
+
+    const provider = vi.fn(async () => ({
+      status: 'failed', output: 'qa failed', error: 'bugs found',
+    }));
+
+    const result = await execute(plan, dispatchMap, { provider });
+
+    expect(result.status).toBe('aborted');
+    expect(result.stepStates['delegate'].status).toBe('failed');
+  });
+
+  it('fails when delegation depth limit is exceeded', async () => {
+    const workflow = makeWorkflow([
+      makeStep({
+        id: 'delegate',
+        role: 'system',
+        intent: 'Deep delegation',
+        delegatesTo: 'some-skill',
+        onFailure: 'abort',
+      }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+    const provider = mockProvider();
+
+    const result = await execute(plan, dispatchMap, {
+      provider,
+      delegationDepth: 2,
+    });
+
+    expect(result.status).toBe('aborted');
+    expect(result.stepStates['delegate'].status).toBe('failed');
+    expect(result.stepStates['delegate'].error).toContain('depth limit');
+  });
+
+  it('fails gracefully when delegated skill cannot be loaded', async () => {
+    const { loadWorkflow: mockLoadWorkflow } = await import('../orchestrator-io.js');
+
+    const workflow = makeWorkflow([
+      makeStep({
+        id: 'delegate',
+        role: 'system',
+        intent: 'Run missing skill',
+        delegatesTo: 'nonexistent-skill',
+        onFailure: 'abort',
+      }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+    const provider = mockProvider();
+
+    vi.mocked(mockLoadWorkflow).mockImplementationOnce(() => {
+      throw new Error('Skill "nonexistent-skill" not found');
+    });
+
+    const result = await execute(plan, dispatchMap, { provider });
+
+    expect(result.status).toBe('aborted');
+    expect(result.stepStates['delegate'].status).toBe('failed');
+    expect(result.stepStates['delegate'].error).toContain('nonexistent-skill');
+  });
+
+  it('retries delegation step when configured', async () => {
+    const { loadWorkflow: mockLoadWorkflow } = await import('../orchestrator-io.js');
+
+    const subWorkflow = makeWorkflow([
+      makeStep({ id: 'sub-1', role: 'qa', onFailure: 'abort' }),
+    ]);
+
+    const workflow = makeWorkflow([
+      makeStep({
+        id: 'delegate',
+        role: 'system',
+        intent: 'Run QA cycle',
+        delegatesTo: 'qa-cycle',
+        retry: { max: 2, on: 'failure' },
+      }),
+    ]);
+    const plan = createExecutionPlan(workflow, { skillName: 'test' });
+    const dispatchMap = makeDispatchMap(plan);
+
+    let calls = 0;
+    vi.mocked(mockLoadWorkflow).mockImplementation(() => ({
+      workflow: subWorkflow,
+      body: '',
+      name: 'qa-cycle',
+    }));
+
+    const provider = vi.fn(async () => {
+      calls++;
+      if (calls === 1) return { status: 'failed', output: 'fail', error: 'bugs' };
+      return { status: 'passed', output: 'ok' };
+    });
+
+    const result = await execute(plan, dispatchMap, { provider });
+
+    expect(result.status).toBe('completed');
+    expect(result.stepStates['delegate'].status).toBe('passed');
+    expect(calls).toBe(2);
   });
 });

--- a/src/utils/executor.js
+++ b/src/utils/executor.js
@@ -3,7 +3,7 @@
  *
  * Drives a plan to completion by iterating through steps, dispatching
  * agent steps to a provider function and system steps to local commands.
- * Sequential execution only (v1.1); parallel groups deferred to v1.2.
+ * Supports parallel execution (v1.2) and delegation to sub-skills.
  */
 
 import { execFile } from 'child_process';
@@ -11,8 +11,15 @@ import {
   advanceStep,
   getNextSteps,
   isPlanComplete,
+  MAX_DELEGATION_DEPTH,
+  createExecutionPlan,
 } from './orchestrator.js';
-import { buildStepContext, recordStepTrace } from './orchestrator-io.js';
+import {
+  buildStepContext,
+  recordStepTrace,
+  loadWorkflow,
+  resolveStepDispatch,
+} from './orchestrator-io.js';
 
 const SYSTEM_STEP_TIMEOUT = 120_000; // 2 minutes
 
@@ -70,7 +77,7 @@ async function executeSystemStep(step, options = {}) {
   }
 
   if (step.delegatesTo) {
-    return { status: 'passed', output: `Delegation to "${step.delegatesTo}" skipped (v1.1)` };
+    return { status: 'passed', output: `System step with delegation — handled by executeDelegation` };
   }
 
   return { status: 'passed', output: 'System step completed' };
@@ -93,11 +100,110 @@ function findStepInPlan(plan, stepId) {
 }
 
 /**
+ * Dispatches a single step (agent or system) and returns its result.
+ *
+ * @param {object} step - Step definition
+ * @param {object} dispatch - Dispatch info for this step
+ * @param {object} context - Execution context
+ * @param {import('./orchestrator.js').ExecutionPlan} context.currentPlan - Current plan state
+ * @param {Function} context.provider - Agent step provider
+ * @param {string} context.projectRoot - Working directory
+ * @param {string} context.skillBody - Skill body text
+ * @param {object} context.executeOptions - Full options passed to execute()
+ * @returns {Promise<{ status: string, output: string, outcome?: object, error?: string }>}
+ */
+async function dispatchStep(step, dispatch, context) {
+  const { currentPlan, provider, projectRoot, skillBody, executeOptions } = context;
+
+  if (step.role === 'system' && step.delegatesTo) {
+    return executeDelegation(step, executeOptions);
+  }
+
+  if (step.role === 'system') {
+    return executeSystemStep(step, { projectRoot });
+  }
+
+  const stepContext = buildStepContext(step, currentPlan, { skillBody });
+  return provider(step, dispatch, stepContext);
+}
+
+/**
+ * Executes a delegation step by loading and running the sub-skill.
+ *
+ * @param {object} step - Delegation step (with delegatesTo field)
+ * @param {object} options - Execute options from parent
+ * @returns {Promise<{ status: string, output: string, error?: string }>}
+ */
+async function executeDelegation(step, options) {
+  const {
+    provider,
+    trace,
+    projectRoot,
+    profile = 'max',
+    onStepStart,
+    onStepEnd,
+    delegationDepth = 0,
+  } = options;
+
+  if (delegationDepth >= MAX_DELEGATION_DEPTH) {
+    return {
+      status: 'failed',
+      output: '',
+      error: `Delegation depth limit (${MAX_DELEGATION_DEPTH}) exceeded at step "${step.id}" delegating to "${step.delegatesTo}"`,
+    };
+  }
+
+  let subSkill;
+  try {
+    subSkill = loadWorkflow(step.delegatesTo);
+  } catch (err) {
+    return {
+      status: 'failed',
+      output: '',
+      error: `Failed to load delegated skill "${step.delegatesTo}": ${err.message}`,
+    };
+  }
+
+  const subPlan = createExecutionPlan(subSkill.workflow, {
+    skillName: subSkill.name || step.delegatesTo,
+  });
+
+  const subDispatchMap = {};
+  for (const group of subPlan.groups) {
+    for (const s of group.steps) {
+      subDispatchMap[s.id] = resolveStepDispatch(s, { profile, projectRoot });
+    }
+  }
+
+  const finalSubPlan = await execute(subPlan, subDispatchMap, {
+    provider,
+    trace,
+    projectRoot,
+    skillBody: subSkill.body || '',
+    onStepStart,
+    onStepEnd,
+    delegationDepth: delegationDepth + 1,
+    profile,
+  });
+
+  if (finalSubPlan.status === 'completed') {
+    return { status: 'passed', output: `Delegation to "${step.delegatesTo}" completed` };
+  }
+
+  return {
+    status: 'failed',
+    output: '',
+    error: `Delegated skill "${step.delegatesTo}" ended with status: ${finalSubPlan.status}`,
+  };
+}
+
+/**
  * Executes a workflow plan to completion.
  *
  * Drives the orchestrator state machine by repeatedly calling getNextSteps,
  * dispatching each step (agent via provider, system via local commands),
- * and advancing the plan with the result.
+ * and advancing the plan with the result. Parallel groups are dispatched
+ * concurrently via Promise.all.
  *
  * @param {import('./orchestrator.js').ExecutionPlan} plan - Initial execution plan
  * @param {Object.<string, import('./orchestrator-io.js').StepDispatchInfo>} dispatchInfoMap - Dispatch info per step
@@ -108,6 +214,8 @@ function findStepInPlan(plan, stepId) {
  * @param {string} [options.skillBody=''] - Skill body text for context building
  * @param {Function} [options.onStepStart] - Callback before each step: (step, dispatch) => void
  * @param {Function} [options.onStepEnd] - Callback after each step: (step, result) => void
+ * @param {number} [options.delegationDepth=0] - Current delegation nesting depth
+ * @param {string} [options.profile='max'] - Model profile for delegation dispatch
  * @returns {Promise<import('./orchestrator.js').ExecutionPlan>} Final plan state
  */
 export async function execute(plan, dispatchInfoMap, options = {}) {
@@ -127,7 +235,6 @@ export async function execute(plan, dispatchInfoMap, options = {}) {
   while (!isPlanComplete(currentPlan)) {
     const { steps, skipped } = getNextSteps(currentPlan);
 
-    // Advance skipped steps first
     for (const stepId of skipped) {
       currentPlan = advanceStep(currentPlan, stepId, { status: 'skipped' });
 
@@ -140,7 +247,6 @@ export async function execute(plan, dispatchInfoMap, options = {}) {
       }
     }
 
-    // If no executable steps remain, check completion again
     if (steps.length === 0) {
       if (isPlanComplete(currentPlan)) break;
       if (++emptyIterations > MAX_EMPTY_ITERATIONS) {
@@ -151,30 +257,34 @@ export async function execute(plan, dispatchInfoMap, options = {}) {
     }
     emptyIterations = 0;
 
-    // v1.1: sequential execution — one step at a time
-    const step = steps[0];
-    const dispatch = dispatchInfoMap[step.id] || {};
+    const dispatchContext = {
+      currentPlan,
+      provider,
+      projectRoot,
+      skillBody,
+      executeOptions: options,
+    };
 
-    onStepStart?.(step, dispatch);
+    const settled = await Promise.all(
+      steps.map(async (step) => {
+        const dispatch = dispatchInfoMap[step.id] || {};
+        onStepStart?.(step, dispatch);
+        const result = await dispatchStep(step, dispatch, dispatchContext);
+        return { step, dispatch, result };
+      })
+    );
 
-    let result;
-    if (step.role === 'system') {
-      result = await executeSystemStep(step, { projectRoot });
-    } else {
-      const context = buildStepContext(step, currentPlan, { skillBody });
-      result = await provider(step, dispatch, context);
+    for (const { step, dispatch, result } of settled) {
+      currentPlan = advanceStep(currentPlan, step.id, result);
+
+      if (trace) {
+        recordStepTrace(trace, step, currentPlan.stepStates[step.id], dispatch);
+      }
+
+      onStepEnd?.(step, result);
     }
-
-    currentPlan = advanceStep(currentPlan, step.id, result);
-
-    if (trace) {
-      recordStepTrace(trace, step, currentPlan.stepStates[step.id], dispatch);
-    }
-
-    onStepEnd?.(step, result);
   }
 
-  // Mark plan as completed if all steps reached terminal state and plan is still running
   if (currentPlan.status === 'running' && isPlanComplete(currentPlan)) {
     currentPlan = { ...currentPlan, status: 'completed' };
   }


### PR DESCRIPTION
## Summary

- **Parallel execution**: Groups marked with `parallel` in workflow YAML now dispatch all steps concurrently via `Promise.all` instead of running only the first step sequentially. This enables `/council` to run its 3 debate agents simultaneously.
- **Delegation**: Steps with `delegates-to` now load the sub-skill, create a sub-plan, and recursively execute it with depth limiting (`MAX_DELEGATION_DEPTH=2`). This enables `/build-feature`'s qa-phase to actually delegate to `/qa-cycle`.
- Extracted `dispatchStep()` helper to route between delegation, system, and agent steps without duplication
- Updated the existing v1.1 delegation test to reflect the new behavior

## Test plan

- [x] 635 tests passing (9 new executor tests)
- [x] Lint clean
- [x] Parallel: concurrent dispatch verified, mixed sequential+parallel groups, failure isolation between peers, callbacks fire for each step
- [x] Delegation: sub-skill execution, failure propagation, depth limit enforcement, graceful load errors, retry on parent step
- [ ] `guild run council --dry-run` shows parallel group for agent-1/2/3
- [ ] `guild run build-feature --dry-run` shows delegation step for qa-phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)