### PR TITLE
feat: Claude Code plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "guild",
+  "displayName": "Guild",
+  "version": "2.0.0",
+  "description": "Spec-first workflows and specialized agent roles for Claude Code. Design docs before code, structured deliberation, session continuity.",
+  "author": {
+    "name": "Guild Agents",
+    "url": "https://github.com/Guild-Agents"
+  },
+  "homepage": "https://guildagents.dev",
+  "repository": "https://github.com/Guild-Agents/guild",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "skills",
+    "spec-driven",
+    "workflows",
+    "council",
+    "tdd",
+    "debugging",
+    "code-review",
+    "session"
+  ],
+  "skills": "./src/templates/skills/"
+}

--- a/agents
+++ b/agents
@@ -1,0 +1,1 @@
+src/templates/agents


### PR DESCRIPTION
## Summary

Guild is now installable as a Claude Code plugin. Users can install with `/plugin install Guild-Agents/guild` and get all 10 skills + 6 agents without needing `npm install` or `guild init`.

### What was added
- `.claude-plugin/plugin.json` — plugin manifest with metadata, keywords, and skill path
- `agents/` symlink — points to `src/templates/agents/` so the plugin system discovers agents at the expected root path

### How it works
- Skills are namespaced as `/guild:build-feature`, `/guild:council`, `/guild:tdd`, etc.
- Agents load via the `agents/` directory convention
- The npm CLI (`guild eval`, `guild doctor`, `guild init`) remains available as a complementary tool
- `claude plugin validate .` passes

### Verified
- `claude plugin validate .` — passes (1 non-blocking warning about CLAUDE.md in repo root)
- `claude --plugin-dir ./` — all 10 skills load correctly with `guild:` namespace
- 242 tests passing, lint clean

## Test plan

- [x] `claude plugin validate .` passes
- [x] `claude --plugin-dir ./` loads all 10 skills
- [x] Skills invocable as `/guild:build-feature`, `/guild:council`, etc.
- [x] 242 tests passing
- [x] Lint clean
- [ ] Submit to claude-plugins-community after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)