### PR TITLE
docs: overhaul README, CHANGELOG, landing, and repo metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [2.1.0] - 2026-05-25
+
+### Added
+
+- **Claude Code plugin support**: Guild is now installable as a Claude Code plugin via `/plugin install Guild-Agents/guild`. Skills are namespaced as `/guild:build-feature`, `/guild:council`, etc.
+- `.claude-plugin/plugin.json` manifest with metadata, keywords, and skill/agent paths
+- `agents/` symlink at plugin root for native agent discovery
+
+## [2.0.0] - 2026-05-25
+
+### Removed
+
+- **Orchestration runtime** (~9,500 lines): executor, orchestrator, dispatch, trace, accounting, pricing, learnings, skill-loader, and Claude Code provider. Guild no longer competes with Claude Code's native Agent/Task tools.
+- **CLI commands**: `guild run`, `guild stats`, `guild logs`, `guild reset-learnings`
+- **Skills**: `/review` (collides with Claude Code built-in `/code-review`), `/verify` (collides with built-in `/verify`), `/new-feature`, `/status`, `/dev-flow` (trivial operations Claude does natively)
+- **Agents**: `product-owner` (redundant with advisor + tech-lead), `db-migration` (stack-specific, unused), `platform-expert` (volatile knowledge), `learnings-extractor` (orphaned after learnings system removal)
+
+### Changed
+
+- Guild is now a **template library + eval framework**, not a runtime. Claude Code executes skill workflows natively.
+- `workflow-parser.js` replaced by minimal `skill-parser.js` for the eval system
+- Workflow YAML simplified: removed executor-specific fields (`commands`, `on-failure`, `retry`, `condition`, `blocking`, `delegates-to`, `parallel`). Only `id`, `role`, `intent`, `requires`, `produces`, `gate`, `model-tier` remain.
+- build-feature pipeline collapsed from 6 phases to 5 (Tech Lead absorbs specification duties)
+- `/session-start` and `/session-end` now integrate with Claude Code's native memory system (SESSION.md for ephemeral state + memory for durable learnings)
+- README and GitHub Pages rewritten for template library positioning
+
+### Final state
+
+- 6 agents, 10 skills, 242 tests, 7 CLI commands
+
+## [1.5.0] - 2026-05-25
+
+### Added
+
+- **Parallel execution** in executor: groups marked with `parallel` in workflow YAML dispatch all steps concurrently via `Promise.all`
+- **Delegation** in executor: steps with `delegates-to` load the sub-skill, create a sub-plan, and recursively execute with depth limiting (`MAX_DELEGATION_DEPTH=2`)
+
+### Changed
+
+- Dependabot updates: vitest 4.1.5, coverage-v8 4.1.5, markdownlint-cli2 0.22.1, eslint 10.3.0, yaml 2.8.4, softprops/action-gh-release v3
+- Resolved `brace-expansion` vulnerability via `npm audit fix`
+- SESSION.md removed from git tracking (stays local for /session-start and /session-end)
+
+## [1.4.0] - 2026-03-31
+
+### Added
+
+- **Semantic matcher**: LLM-based trigger testing via Anthropic Haiku (`guild eval --semantic`)
+- **Benchmark aggregation**: rolling 30-entry history with per-skill accuracy, precision, recall, and delta vs previous run. Regressions (>5% accuracy drop) flagged automatically.
+- **Description analyzer**: keyword gap detection with improvement suggestions (`guild eval --suggest`)
+- **Trigger tests** for all 15 skills (120 total test cases)
+- `guild eval --triggers` for keyword-based trigger accuracy testing
+
 ## [1.3.0] - 2026-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,152 +1,155 @@
 # Guild
 
 [![npm version](https://img.shields.io/npm/v/guild-agents)](https://www.npmjs.com/package/guild-agents)
+[![npm downloads](https://img.shields.io/npm/dm/guild-agents)](https://www.npmjs.com/package/guild-agents)
 [![CI](https://github.com/guild-agents/guild/actions/workflows/ci.yml/badge.svg)](https://github.com/guild-agents/guild/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
 **Guild makes Claude Code think before it builds.**
 
-Without Guild, Claude Code writes code immediately. No evaluation, no design, no review. With Guild, every feature goes through structured phases — evaluated by an advisor, designed by a tech lead, reviewed by a code reviewer, validated by QA — before anything ships. Everything is markdown in `.claude/`, tracked by git, works offline, zero infrastructure.
+Without Guild, Claude Code writes code immediately. No evaluation, no design, no review. With Guild, every feature goes through structured phases — evaluated by an advisor, designed by a tech lead, reviewed, and validated — before anything ships.
+
+```bash
+npx guild-agents init
+```
 
 ## The Problem
 
-Without structure, Claude Code:
-
-- Writes code before understanding the problem
-- Has no design phase and no review gate
-- Loses decisions between sessions
-- Produces results that vary with every conversation
+Claude Code is powerful but unstructured. Ask it to "add authentication" and it starts writing code immediately. No one evaluated whether the approach makes sense. No design doc captures the trade-offs. No review gate catches issues before they compound. Next session, all that context is gone.
 
 ## How Guild Solves It
 
-- **Spec before code**: `/build-feature` enforces evaluation, design, and review phases — code comes after the design doc
-- **Independent perspectives**: `/council` spawns parallel agents that each analyze your idea independently, then synthesize into a decision
-- **Session continuity**: `/session-start` and `/session-end` combine SESSION.md with Claude Code's memory system — you never lose context between sessions
-- **Behavioral discipline**: `/tdd` and `/debug` prevent the most common LLM anti-patterns: code before tests, fixes before root cause analysis
-- **Quality you can measure**: `guild eval` validates skill structure, trigger accuracy, and description quality with automated benchmarks
+Guild installs **spec-first workflows** and **specialized role definitions** as `.claude/` markdown files in your project. Claude Code reads them natively as slash commands. The process enforces quality gates — you can't skip evaluation, you can't ship without review.
 
-## Quick Start
+- **`/guild:build-feature`** — 5-phase pipeline: evaluate, design, implement, review, QA. Code comes after the design doc.
+- **`/guild:council`** — 3 agents analyze your idea in parallel with different perspectives, then synthesize into a decision with a spec document.
+- **`/guild:tdd`** — No production code without a failing test first. Enforces red-green-refactor.
+- **`/guild:debug`** — No fixes without root cause investigation. Systematic 4-phase process.
+- **`/guild:session-start`** / **`/guild:session-end`** — SESSION.md captures where you stopped. Claude Code memory captures what you learned. You resume with full context.
+
+## Quality You Can Measure
+
+Most agent frameworks can't tell you if their skills actually fire when they should. Guild ships a benchmark suite.
+
+```bash
+guild eval                # Structural assertions: steps exist, roles correct, gates present
+guild eval --triggers     # Trigger accuracy: do user prompts route to the right skill?
+guild eval --semantic     # LLM-based scoring via Haiku for higher-fidelity testing
+guild eval --suggest      # Keyword gap analysis with improvement suggestions
+```
+
+Every trigger run records results to a rolling benchmark with per-skill accuracy, precision, recall, and delta vs previous run. Regressions are caught before they ship.
+
+## The Pipeline
+
+```text
+/guild:build-feature "Add JWT auth"
+         |
+         v
+    +-----------+     +-----------+     +-----------+
+    | Evaluate  |---->|  Design   |---->|   Build   |
+    |  advisor  |     | tech-lead |     | developer |
+    +-----------+     +-----------+     +-----+-----+
+                                              |
+                                        +-----+-----+
+                                        v           v
+                                  +-----------++-----------+
+                                  |  Review   ||    QA     |
+                                  +-----------++-----------+
+```
+
+Five phases. Phases 1-2 happen before any code is written. Gates between phases can't be skipped.
+
+## Install
+
+**As a Claude Code plugin** (recommended):
+
+```
+/plugin install Guild-Agents/guild
+```
+
+All 10 skills and 6 roles are available immediately as `/guild:*` commands.
+
+**As an npm package** (for the eval CLI):
 
 ```bash
 npm install -g guild-agents
 guild init
 ```
 
-Then use skills as slash commands in Claude Code:
-
-```text
-/guild-specialize        # Learn your codebase, enrich CLAUDE.md
-/council "Add JWT auth"  # Spec a feature through structured deliberation
-/build-feature           # Implement from spec through the full pipeline
-```
-
-## The Pipeline
-
-```text
-You ──> /build-feature "Add JWT auth"
-         │
-         ▼
-    ┌──────────┐     ┌──────────┐     ┌──────────┐
-    │ Evaluate │────>│  Design  │────>│  Build   │
-    │ advisor  │     │ tech-lead│     │developer │
-    └──────────┘     └──────────┘     └────┬─────┘
-                                           │
-                                     ┌─────┴─────┐
-                                     ▼           ▼
-                               ┌──────────┐┌──────────┐
-                               │  Review  ││    QA    │
-                               └──────────┘└──────────┘
-```
-
-Five phases: **evaluate**, **design**, **implement**, **review**, **validate**. Phases 1-2 happen before any code is written.
-
 ## Skills
-
-10 skills, available as slash commands in Claude Code:
 
 | Skill | What it does |
 | --- | --- |
-| `/build-feature` | Full pipeline: evaluate, design, implement, review, QA |
-| `/council` | Multi-perspective deliberation — 3 agents debate independently, then synthesize |
-| `/create-pr` | Structured pull request from current branch |
-| `/qa-cycle` | QA and bugfix loop until clean |
-| `/tdd` | TDD red-green-refactor — no code without a failing test |
-| `/debug` | Systematic 4-phase debugging — no fixes without root cause |
-| `/guild-specialize` | Explore your codebase, enrich CLAUDE.md with real conventions |
-| `/re-specialize` | Incremental update of CLAUDE.md when your stack changes |
-| `/session-start` | Resume work from SESSION.md + Claude Code memory |
-| `/session-end` | Save state to SESSION.md + durable learnings to memory |
+| `/guild:build-feature` | Full 5-phase pipeline with quality gates |
+| `/guild:council` | Multi-perspective deliberation — 3 roles debate, then synthesize |
+| `/guild:create-pr` | Structured pull request from current branch |
+| `/guild:qa-cycle` | QA and bugfix loop until clean |
+| `/guild:tdd` | TDD red-green-refactor — no code without a failing test |
+| `/guild:debug` | Systematic 4-phase debugging — no fixes without root cause |
+| `/guild:guild-specialize` | Explore your codebase, enrich CLAUDE.md with real conventions |
+| `/guild:re-specialize` | Incremental update when your stack changes |
+| `/guild:session-start` | Resume from SESSION.md + Claude Code memory |
+| `/guild:session-end` | Save state + durable learnings to memory |
 
-## Agents
+## Roles
 
-6 specialized roles that give Claude Code distinct perspectives:
+6 role definitions that give Claude Code distinct perspectives:
 
-| Agent | Role |
+| Role | Perspective |
 | --- | --- |
-| advisor | Evaluates ideas and provides strategic direction. First gate before any work begins |
-| tech-lead | Breaks features into tasks. Defines technical approach and architecture |
-| developer | Implements features following project conventions. Writes tests, makes atomic commits |
-| code-reviewer | Reviews quality, patterns, and technical debt |
-| qa | Testing, edge cases, regression. Validates the implementation meets acceptance criteria |
-| bugfix | Diagnosis and bug resolution. Isolates root causes and applies targeted fixes |
+| advisor | Strategic direction. First gate — evaluates ideas before work begins |
+| tech-lead | Technical approach. Breaks features into tasks with acceptance criteria |
+| developer | Implementation. Follows conventions, writes tests, makes atomic commits |
+| code-reviewer | Quality. Reviews patterns, security, and technical debt |
+| qa | Validation. Tests edge cases, regressions, acceptance criteria |
+| bugfix | Diagnosis. Isolates root causes, applies targeted fixes |
 
-Each agent is a flat `.md` file with identity, responsibilities, and boundaries. Claude Code reads them via its native Agent tool and assumes the role.
+Each role is a `.md` file with identity, responsibilities, and boundaries. Claude Code reads them via its native Agent tool.
+
+## Session Continuity
+
+Claude Code's memory system stores long-term knowledge (who you are, lessons learned). But it explicitly excludes ephemeral work state — what you were building, which branch, what phase. That's the gap Guild fills.
+
+`/guild:session-end` writes to **both layers**:
+- **SESSION.md** — where you stopped: task, branch, phase, next steps (overwritten each session)
+- **Claude Code memory** — what you learned: decisions, lessons, references (persists across sessions)
+
+`/guild:session-start` reads from **both** and presents a unified summary.
+
+## When NOT to Use Guild
+
+Guild is overkill for: throwaway scripts, exploratory prototypes, single-file utilities, or anything where you'd rather ship fast than ship right. The 5-phase pipeline has cost — use it when that cost buys you something.
+
+## How Is This Different?
+
+Guild isn't an editor (Cursor), isn't a pair-programmer (Aider), isn't an autonomous agent (Devin). It's a **methodology layer** on top of Claude Code. If you already use Claude Code and want structured spec-first workflows with quality gates, Guild adds the discipline. If you don't use Claude Code, Guild isn't for you.
+
+## How It Works
+
+Guild installs role definitions and skill workflows as markdown files in `.claude/`. Claude Code discovers and executes them natively — no custom runtime, no extra process, no API calls. When you type `/guild:build-feature`, Claude Code reads the skill, follows the phases, and spawns agents using its own Agent tool.
+
+Guild defines **what** happens. Claude Code decides **how** to execute it.
 
 ## CLI
 
 ```bash
 guild init              # Interactive project onboarding
-guild new-agent <name>  # Create a custom agent
+guild new-agent <name>  # Create a custom role
 guild status            # Show project status
 guild doctor            # Diagnose setup
-guild list              # List agents and skills
+guild list              # List roles and skills
 guild eval              # Run structural skill evaluations
-guild eval --triggers   # Run trigger accuracy tests
-guild eval --semantic   # LLM-based trigger tests (requires ANTHROPIC_API_KEY)
-guild eval --suggest    # Description improvement suggestions
 guild workspace init    # Create a multi-repo workspace
 ```
 
-## Skill Evaluations
-
-Guild includes a built-in framework for measuring skill quality:
-
-- **Structural evals** -- assert workflow structure: steps exist, roles are correct, gates are present
-- **Trigger tests** -- verify that user prompts route to the correct skill
-- **Semantic matcher** -- LLM-based scoring for higher-fidelity trigger testing
-- **Benchmarks** -- rolling history with per-skill accuracy, precision, recall, and regression detection
-
-## How It Works
-
-Guild installs agent definitions and skill workflows as markdown files in your project's `.claude/` directory. Claude Code discovers and executes them natively — no custom runtime, no extra process, no API calls. When you type `/build-feature`, Claude Code reads the skill, follows the phases, and spawns agents using its own Agent tool.
-
-Guild defines **what** happens. Claude Code decides **how** to execute it.
-
-## Session Continuity
-
-Claude Code's native memory system remembers who you are, lessons learned, and project context — knowledge that lasts months. But it explicitly does not store ephemeral work state: what you were building, which branch, what phase, what's next. That's the gap Guild fills.
-
-`/session-end` writes to **both layers**:
-
-- **SESSION.md** — where you stopped: task, branch, phase, next steps (overwritten each session)
-- **Claude Code memory** — what you learned: decisions, lessons, references (persists across sessions)
-
-`/session-start` reads from **both** and presents a unified summary. You resume exactly where you left off, with full context of what you know and what you were doing.
-
 ## Guild Builds Itself
 
-Every feature in Guild goes through the same spec-first pipeline that Guild installs in your project. Guild's own design decisions live in `docs/specs/`.
-
-## Requirements
-
-- Node.js >= 20
-- Claude Code
-- `gh` CLI (optional, for GitHub integration)
+Every feature in Guild goes through the same spec-first pipeline that Guild installs in your project.
 
 ## Contributing
 
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for setup, branching, and contribution guidelines.
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1382,6 +1382,36 @@
             Works in any project, any language, any stack.
           </p>
         </div>
+
+        <div class="why-card reveal reveal-delay-5" style="grid-column: 1 / -1; max-width: 600px; margin: 0 auto;">
+          <h3 class="why-card-title">Measurable skill quality</h3>
+          <p class="why-card-text">
+            <code style="color: var(--green); background: var(--green-dim); padding: 2px 8px; border-radius: 3px;">guild eval</code> validates that your skills route correctly, follow expected structure, and don't regress. Built-in benchmarking with accuracy, precision, recall, and regression detection.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       CTA
+       ============================================================ -->
+  <section style="padding: 80px 0; text-align: center;">
+    <div class="container">
+      <div class="reveal">
+        <h2 class="section-title">Get started in 30 seconds</h2>
+        <p class="section-subtitle" style="margin: 0 auto 32px;">
+          Install as a Claude Code plugin or via npm.
+        </p>
+        <div style="display: flex; flex-direction: column; align-items: center; gap: 16px;">
+          <div style="background: var(--bg-card); border: 1px solid var(--border-gold); border-radius: 8px; padding: 14px 24px; font-family: var(--font-code); font-size: 0.9rem;">
+            <span style="color: var(--gold);">/</span><span style="color: var(--green);">plugin install Guild-Agents/guild</span>
+          </div>
+          <span style="color: var(--text-muted); font-size: 0.85rem;">or</span>
+          <div style="background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 8px; padding: 14px 24px; font-family: var(--font-code); font-size: 0.9rem;">
+            <span style="color: var(--text-muted);">$</span> <span style="color: var(--green);">npx guild-agents init</span>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Comprehensive docs overhaul based on external review feedback.

- **README restructured**: eval system promoted to 3rd section, "When NOT to Use Guild" and "How Is This Different?" sections added, terminology shifted from "agents" to "roles", npm downloads badge added
- **CHANGELOG gap fixed**: added v1.4.0 through v2.1.0 entries (was missing everything after v1.3.0)
- **Landing page**: 5th "Why Guild" card for measurable skill quality, CTA section at bottom with plugin install command
- **Repo metadata**: description updated to spec-driven positioning, topics cleaned (removed multi-agent/ai-agents, added spec-driven/design-docs/claude-code-plugin)

## Test plan

- [x] 242 tests passing
- [x] Lint clean
- [ ] Review README flow and messaging
- [ ] Review landing page at guildagents.dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)